### PR TITLE
Update version requirements to 9.6.3+ and 10.2+

### DIFF
--- a/getting-started/installation-apt-debian.md
+++ b/getting-started/installation-apt-debian.md
@@ -2,7 +2,7 @@
 
 This will install TimescaleDB via `apt` on Debian distros.
 
-**Note: TimescaleDB requires PostgreSQL 9.6 or later+**
+**Note: TimescaleDB requires PostgreSQL 9.6.3+ or 10.2+**
 
 #### Prerequisites
 

--- a/getting-started/installation-apt-ubuntu.md
+++ b/getting-started/installation-apt-ubuntu.md
@@ -2,7 +2,7 @@
 
 This will install TimescaleDB via `apt` on Ubuntu distros.
 
-**Note: TimescaleDB requires PostgreSQL 9.6 or later+**
+**Note: TimescaleDB requires PostgreSQL 9.6.3+ or 10.2+**
 
 #### Prerequisites
 
@@ -25,9 +25,9 @@ sure to remove non-`apt` installations before using this method.
 sudo add-apt-repository ppa:timescale/timescaledb-ppa
 sudo apt-get update
 
-# To install for PG 9.6
+# To install for PG 9.6.3+
 sudo apt install timescaledb-postgresql-9.6
-# To install for PG 10
+# To install for PG 10.2+
 sudo apt install timescaledb-postgresql-10
 ```
 

--- a/getting-started/installation-homebrew.md
+++ b/getting-started/installation-homebrew.md
@@ -2,7 +2,7 @@
 
 This will install both TimescaleDB *and* PostgreSQL via Homebrew.
 
-**Note: TimescaleDB requires PostgreSQL 9.6 or later+**
+**Note: TimescaleDB requires PostgreSQL 9.6.3+ or 10.2+**
 
 #### Prerequisites
 

--- a/getting-started/installation-source-windows.md
+++ b/getting-started/installation-source-windows.md
@@ -1,6 +1,6 @@
 ## From Source (Windows) [](installation-source)
 
-**Note: TimescaleDB requires PostgreSQL 9.6 or later+**
+**Note: TimescaleDB requires PostgreSQL 9.6.3+ or 10.2+**
 
 #### Prerequisites
 

--- a/getting-started/installation-source.md
+++ b/getting-started/installation-source.md
@@ -1,6 +1,6 @@
 ## From Source [](installation-source)
 
-**Note: TimescaleDB requires PostgreSQL 9.6 or later+**
+**Note: TimescaleDB requires PostgreSQL 9.6.3+ or 10.2+**
 
 #### Prerequisites
 

--- a/getting-started/installation-windows.md
+++ b/getting-started/installation-windows.md
@@ -1,6 +1,6 @@
 ## Windows ZIP Installer [](installation-windows)
 
-**Note: TimescaleDB requires PostgreSQL 9.6 or later+**
+**Note: TimescaleDB requires PostgreSQL 9.6.3+ or 10.2+**
 
 #### Prerequisites
 

--- a/getting-started/installation-yum.md
+++ b/getting-started/installation-yum.md
@@ -3,7 +3,7 @@
 This will install both TimescaleDB *and* PostgreSQL via `yum`
 (or `dnf` on Fedora).
 
-**Note: TimescaleDB requires PostgreSQL 9.6 or later+**
+**Note: TimescaleDB requires PostgreSQL 9.6.3+ or 10.2+**
 
 #### Prerequisites
 


### PR DESCRIPTION
Due to some bugs and breaking changes in earlier versions of PG 9.6
and 10, we need to be more strict with our requirements for which
versions TimescaleDB works with. As of version 0.11.0, the code
will require at least 9.6.3 for PG 9.6 installations and at least
10.2 for PG 10 installations.