### PR TITLE
Clarify that increasing ids must specify interval

### DIFF
--- a/getting-started/creating-hypertables.md
+++ b/getting-started/creating-hypertables.md
@@ -41,7 +41,8 @@ SELECT create_hypertable('conditions', 'time', 'location', 4);
 >:TIP: The 'time' column used in the `create_hypertable` function supports
 timestamp, date, or integer types, so you can use a parameter that is not
 explicitly time-based, as long as it can increment.  For example, a
-monotonically increasing id would work.
+monotonically increasing id would work. You must specify a chunk time interval
+when creating a hypertable if you use a monotonically increasing id.  
 
 ### Inserting & Querying [](inserting-querying)
 Inserting data into the hypertable is done via normal SQL `INSERT` commands,


### PR DESCRIPTION
Comes from customer confusion around creating a hypertable with incrementing ids (vs timestamps). This commit adds a clarifying sentence to the tooltip that notifies users that any integer can be used in place of a timestamp.