### PR TITLE
Rewrite gap filling queries to not use CTE

### DIFF
--- a/using-timescaledb/reading-data.md
+++ b/using-timescaledb/reading-data.md
@@ -277,9 +277,9 @@ This query will then output data in the following form:
  2017-09-22 |   9855
 ```
 Unlike with date_trunc, we can use a custom time interval with the time_bucket function,
-but in order for the generates times to align with the subselect we need use time_bucket on
+but in order for the generated times to align with the subselect we need to use time_bucket on
 the first argument to generate_series.
-For example, let's say you want 1080 data points in the last two weeks, and as many graphing
+For example, let's say you want 1080 data points in the last two weeks and, as many graphing
 libraries require time data points with null values to draw gaps in a graph, we need to
 generate the correct timestamp for each of the data points even if there is no data there.
 Note that we can do basic arithmetic operations on intervals easily in order to get the correct

--- a/using-timescaledb/reading-data.md
+++ b/using-timescaledb/reading-data.md
@@ -289,14 +289,18 @@ SELECT
   period AS time,
   avg_data
 FROM
-  generate_series(time_bucket(interval '2 weeks' / 1080, now()-'2 weeks'::interval), now(), '2 weeks'::interval / 1080) AS period
+  generate_series(
+    time_bucket(interval '2 weeks' / 1080, now() - interval '2 weeks'),
+    now(),
+    interval '2 weeks' / 1080
+  ) AS period
   LEFT JOIN (
     SELECT
-      time_bucket('2 weeks'::interval / 1080, time::timestamptz) as btime,
+      time_bucket(interval '2 weeks' / 1080, time::timestamptz) as btime,
       avg(data_value) as avg_data
     FROM my_hypertable
     WHERE
-      time > now() - '2 weeks'::interval
+      time > now() - interval '2 weeks'
       AND meter_id = 1
     GROUP BY 1
   ) t ON t.btime = period;


### PR DESCRIPTION
This modifies the 2 gap filling queries in the docs section to not use CTEs.