### PR TITLE
Add migration schema gotchas

### DIFF
--- a/api.md
+++ b/api.md
@@ -191,6 +191,11 @@ in the table.
 >
 >If you would like finer control over index formation and other aspects
     of your hypertable, [follow these migration instructions instead][migrate-from-postgresql].
+>
+>When converting a normal SQL table to a hypertable, pay attention
+to how you handle constraints. A hypertable can contain foreign keys to normal SQL table
+columns, but the reverse is not allowed. UNIQUE and PRIMARY constraints must include the
+partitioning key.
 <!-- -->
 #### Units
 

--- a/getting-started/migrating-data.md
+++ b/getting-started/migrating-data.md
@@ -18,6 +18,10 @@ altogether, [follow these instructions][different-db].
 ### 2. Importing data from `.csv`
 If you have a dataset stored in a `.csv` file, you can import it into an empty TimescaleDB hypertable. [follow these instructions][import-data]
 
+>:TIP: When converting a normal SQL table to a hypertable, pay attention to how you handle constraints.
+A hypertable can contain foreign keys to normal SQL table columns, but the reverse is not allowed.
+UNIQUE and PRIMARY constraints must include the partitioning key. 
+
 ---
 
 ## Migrate from the Same Database [](same-db)
@@ -208,7 +212,7 @@ resources and reduce the performance improvements.
 #### Using PostgreSQL's `COPY`
 
 Although we recommend our [open sourced Go program][parallel importer]
-for better bulk insert performance, we can also use PostgreSQL's bulk insert command `COPY` to copy data 
+for better bulk insert performance, we can also use PostgreSQL's bulk insert command `COPY` to copy data
 from the `.csv` into our new db:
 
 ```bash


### PR DESCRIPTION
Based on some comments from @mfreed a while back, we should highlight some compatibility issues uses should be aware of when considering a migration to TimescaleDB. This adds a tip that describes how constraints should be defined in a hypertable vs a normal table.