### PR TITLE
Re-order postgresql.conf instructions

### DIFF
--- a/getting-started/installation-apt-debian.md
+++ b/getting-started/installation-apt-debian.md
@@ -37,6 +37,14 @@ them with `sudo apt install -f` and then re-run the `dpkg` command.
 
 #### Update `postgresql.conf`
 
+>:TIP: The usual location of `postgres.conf`
+is `/etc/postgresql/9.6/main/postgresql.conf` for 9.6 and
+`/etc/postgresql/10/main/postgresql.conf` for 10, but this may vary
+depending on your setup. If you are unsure where your `postgresql.conf` file 
+is located, you can query PostgreSQL through the psql interface using `SHOW config_file;`.
+Please note that you must have created a `postgres` superuser so that you can access the psql
+interface.
+
 You will need to edit your `postgresql.conf` file to include
 necessary libraries:
 ```bash
@@ -44,11 +52,6 @@ necessary libraries:
 # For example:
 shared_preload_libraries = 'timescaledb'
 ```
-
->:TIP: The usual location of `postgres.conf`
-is `/etc/postgresql/9.6/main/postgresql.conf` for 9.6 and
-`/etc/postgresql/10/main/postgresql.conf` for 10, but this may vary
-depending on your setup.
 
 >:TIP: If you have other libraries you are preloading, they should be comma separated.
 

--- a/getting-started/installation-apt-ubuntu.md
+++ b/getting-started/installation-apt-ubuntu.md
@@ -33,6 +33,14 @@ sudo apt install timescaledb-postgresql-10
 
 #### Update `postgresql.conf`
 
+>:TIP: The usual location of `postgres.conf`
+is `/etc/postgresql/9.6/main/postgresql.conf` for 9.6 and
+`/etc/postgresql/10/main/postgresql.conf` for 10, but this may vary
+depending on your setup. If you are unsure where your `postgresql.conf` file
+is located, you can query PostgreSQL through the psql interface using `SHOW config_file;`.
+Please note that you must have created a `postgres` superuser so that you can access the psql
+interface. 
+
 You will need to edit your `postgresql.conf` file to include
 necessary libraries:
 ```bash
@@ -40,11 +48,6 @@ necessary libraries:
 # For example:
 shared_preload_libraries = 'timescaledb'
 ```
-
->:TIP: The usual location of `postgres.conf`
-is `/etc/postgresql/9.6/main/postgresql.conf` for 9.6 and
-`/etc/postgresql/10/main/postgresql.conf` for 10, but this may vary
-depending on your setup.
 
 >:TIP: If you have other libraries you are preloading, they should be comma separated.
 

--- a/getting-started/installation-homebrew.md
+++ b/getting-started/installation-homebrew.md
@@ -29,6 +29,13 @@ brew install timescaledb
 
 #### Update Postgresql.conf
 
+>:TIP: The usual location of `postgresql.conf` is
+`/usr/local/var/postgres/postgresql.conf`, but this may vary depending on
+your setup. If you are unsure where your `postgresql.conf` file is located, you
+can query PostgreSQL through the psql interface using `SHOW config_file;`. Please note
+that you must have created a `postgres` superuser so that you can access the psql
+interface.
+
 Also, you will need to edit your `postgresql.conf` file to include
 necessary libraries:
 
@@ -37,9 +44,6 @@ necessary libraries:
 # For example:
 shared_preload_libraries = 'timescaledb'
 ```
->:TIP: The usual location of `postgres.conf` is
-`/usr/local/var/postgres/postgresql.conf`, but this may vary depending on
-your setup.
 
 >:TIP: If you have other libraries you are preloading, they should be comma separated.
 

--- a/getting-started/installation-yum.md
+++ b/getting-started/installation-yum.md
@@ -42,6 +42,14 @@ sudo yum install timescaledb
 
 #### Update `postgresql.conf`
 
+>:TIP: The usual location of `postgres.conf`
+is `/var/lib/pgsql/9.6/data/postgresql.conf` for PostgreSQL 9.6
+and `/var/lib/pgsql/10/data/postgresql.conf` for PostgreSQL 10,
+but this may vary depending on your setup. If you are unsure where your `postgresql.conf` file
+is located, you can query PostgreSQL through the psql interface using `SHOW config_file;`.
+Please note that you must have created a `postgres` superuser so that you can access the psql
+interface. 
+
 You will need to edit your `postgresql.conf` file to include
 necessary libraries:
 ```bash
@@ -49,11 +57,6 @@ necessary libraries:
 # For example:
 shared_preload_libraries = 'timescaledb'
 ```
-
->:TIP: The usual location of `postgres.conf`
-is `/var/lib/pgsql/9.6/data/postgresql.conf` for PostgreSQL 9.6
-and `/var/lib/pgsql/10/data/postgresql.conf` for PostgreSQL 10,
-but this may vary depending on your setup.
 
 >:TIP: If you have other libraries you are preloading, they should be comma separated.
 


### PR DESCRIPTION
When you run through the install instructions that require an edit to postgresql.conf, the nice tooltip that tells you where it lives comes after the actual instructions. Move this up to before the instructions so that users have this info before they try to make a postgresql.conf edit.