### PR TITLE
Add in packaged prometheus adapter in installation instructions

### DIFF
--- a/getting-started/installation-docker.md
+++ b/getting-started/installation-docker.md
@@ -92,6 +92,20 @@ CREATE EXTENSION postgis;
 ```
 For more instructions on using PostGIS, [see our tutorial][tutorial-postgis].
 
+## Prebuilt with Prometheus adapter
+
+We have a Prometheus adapter and extension that, when used together, allow you to
+both query and write to TimescaleDB as a long-term store for Prometheus. This
+image is published under the name `timescale/pg_prometheus` rather than `timescale/timescaledb`.
+To download and run this image, follow the same instructions as above, but use this image name
+instead.
+
+You can also manually install the adapter and extension. Our [Prometheus storage adapter][adapter-github]
+can be compiled from source code or downloaded as a Linux or Darwin binary. Our [pg_prometheus extension][prometheus-extension] can be compiled from source code. Please visit the associated
+GitHub links for more information.
+
+For more instructions on using our Prometheus adapter, [see our tutorial][tutorial-prometheus].
+
 [official-image]: https://github.com/docker-library/postgres/
 [docker-vulnerability]: https://www.techrepublic.com/article/how-to-fix-the-docker-and-ufw-security-flaw
 [alpine Linux]: https://alpinelinux.org/
@@ -99,3 +113,6 @@ For more instructions on using PostGIS, [see our tutorial][tutorial-postgis].
 [docker-run.sh]: https://github.com/timescale/timescaledb/blob/master/scripts/docker-run.sh
 [docker-data-volumes]: https://docs.docker.com/engine/tutorials/dockervolumes/#data-volumes
 [tutorial-postgis]: http://docs.timescale.com/tutorials/tutorial-hello-nyc#tutorial-postgis
+[tutorial-prometheus]: /tutorials/prometheus-adapter
+[adapter-github]: https://github.com/timescale/prometheus-postgresql-adapter
+[prometheus-extension]: https://github.com/timescale/pg_prometheus


### PR DESCRIPTION
Add in prometheus adapter Docker image in our installation instructions. Next step will be to surface these instructions as a first-class click through at the top of the page. 