### PR TITLE
Update apt installation pages to be more streamline

### DIFF
--- a/getting-started/installation-apt-debian.md
+++ b/getting-started/installation-apt-debian.md
@@ -6,9 +6,7 @@ This will install TimescaleDB via `apt` on Debian distros.
 
 #### Prerequisites
 
-- Debian 7, 8, or 9.
-- A standard PostgreSQL installation.
-See [here for instructions][postgresql-apt] to install via `apt`.
+- Debian 7 (wheezy), 8 (jessie), or 9 (stretch).
 
 #### Build & Install
 
@@ -18,19 +16,27 @@ If you wish to maintain your current version of PostgreSQL outside
 of `apt`, we recommend installing from source.  Otherwise, please be
 sure to remove non-`apt` installations before using this method.
 
+**If you don't already have PostgreSQL installed**, add PostgreSQL's third
+party repository to get the latest PostgreSQL packages:
 ```bash
-# Fetch the correct .deb (e.g., Debian 9 and PostgreSQL 9.6)
-wget https://timescalereleases.blob.core.windows.net/debian/timescaledb-postgresql-9.6_x.y.z~debian9_amd64.deb
+# `lsb_release -c -s` should return the correct codename of your OS
+sudo sh -c "echo 'deb http://apt.postgresql.org/pub/repos/apt/ `lsb_release -c -s`-pgdg main' >> /etc/apt/sources.list.d/pgdg.list"
+wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
+sudo apt-get update
+```
 
-# Install via apt-get
-sudo apt-get install ./timescaledb-postgresql-9.6_x.y.z~debian9_amd64.deb
+Add TimescaleDB's third party repository and install TimescaleDB (will download
+any dependencies it needs from the PostgreSQL repo):
+```bash
+# Add our repository
+sudo sh -c "echo 'deb https://packagecloud.io/timescale/timescaledb/debian/ `lsb_release -c -s` main' > /etc/apt/sources.list.d/timescaledb.list"
+wget --quiet -O - https://packagecloud.io/timescale/timescaledb/gpgkey | sudo apt-key add -
+sudo apt-get update
 
-# Alternate file names to wget:
-# - timescaledb-postgresql-9.6_x.y.z~debian8_amd64.deb
-# - timescaledb-postgresql-9.6_x.y.z~debian7_amd64.deb
-# - timescaledb-postgresql-10_x.y.z~debian9_amd64.deb
-# - timescaledb-postgresql-10_x.y.z~debian8_amd64.deb
-# - timescaledb-postgresql-10_x.y.z~debian7_amd64.deb
+# To install for PG 10.2+
+sudo apt-get install timescaledb-postgresql-10
+# To install for PG 9.6.3+
+sudo apt-get install timescaledb-postgresql-9.6
 ```
 
 #### Update `postgresql.conf`
@@ -63,4 +69,3 @@ sudo service postgresql restart
 [Here are some instructions to create the `postgres` superuser][createuser].
 
 [createuser]: http://suite.opengeo.org/docs/latest/dataadmin/pgGettingStarted/firstconnect.html
-[postgresql-apt]: https://www.postgresql.org/download/linux/debian/

--- a/getting-started/installation-apt-ubuntu.md
+++ b/getting-started/installation-apt-ubuntu.md
@@ -9,8 +9,6 @@ This will install TimescaleDB via `apt` on Ubuntu distros.
 - Ubuntu 14.04 or later, except obsoleted versions.
 Check [releases.ubuntu.com][ubuntu-releases] for list of
 non-obsolete releases.
-- A standard PostgreSQL installation.
-See [here for instructions][postgresql-apt] to install via `apt`.
 
 #### Build & Install
 
@@ -20,15 +18,26 @@ If you wish to maintain your current version of PostgreSQL outside
 of `apt`, we recommend installing from source.  Otherwise, please be
 sure to remove non-`apt` installations before using this method.
 
+**If you don't already have PostgreSQL installed**, add PostgreSQL's third
+party repository to get the latest PostgreSQL packages:
+```bash
+# `lsb_release -c -s` should return the correct codename of your OS
+sudo sh -c "echo 'deb http://apt.postgresql.org/pub/repos/apt/ `lsb_release -c -s`-pgdg main' >> /etc/apt/sources.list.d/pgdg.list"
+wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
+sudo apt-get update
+```
+
+Add TimescaleDB's third party PPA and install TimescaleDB (will download
+any dependencies it needs from the PostgreSQL repo):
 ```bash
 # Add our PPA
 sudo add-apt-repository ppa:timescale/timescaledb-ppa
 sudo apt-get update
 
-# To install for PG 9.6.3+
-sudo apt install timescaledb-postgresql-9.6
 # To install for PG 10.2+
 sudo apt install timescaledb-postgresql-10
+# To install for PG 9.6.3+
+sudo apt install timescaledb-postgresql-9.6
 ```
 
 #### Update `postgresql.conf`
@@ -39,7 +48,7 @@ is `/etc/postgresql/9.6/main/postgresql.conf` for 9.6 and
 depending on your setup. If you are unsure where your `postgresql.conf` file
 is located, you can query PostgreSQL through the psql interface using `SHOW config_file;`.
 Please note that you must have created a `postgres` superuser so that you can access the psql
-interface. 
+interface.
 
 You will need to edit your `postgresql.conf` file to include
 necessary libraries:
@@ -62,4 +71,3 @@ sudo service postgresql restart
 
 [createuser]: http://suite.opengeo.org/docs/latest/dataadmin/pgGettingStarted/firstconnect.html
 [ubuntu-releases]: http://releases.ubuntu.com/
-[postgresql-apt]: https://www.postgresql.org/download/linux/ubuntu/


### PR DESCRIPTION
This removes the external link for installing the third party repo
for PostgreSQL. For simplicity we make this a mostly recommended
step so users don't get mixed up with the stable versions offered
by the OS itself.

Debian instructions are updated to use the packagecloud.io
repository now for a cleaner, more Debian-like install process.