### PR TITLE
Simplify install instructions with pg-version

### DIFF
--- a/getting-started/installation-apt-debian.md
+++ b/getting-started/installation-apt-debian.md
@@ -6,7 +6,7 @@ This will install TimescaleDB via `apt` on Debian distros.
 
 #### Prerequisites
 
-- Debian 7 (wheezy), 8 (jessie), or 9 (stretch).
+- Debian 8 (jessie) or 9 (stretch)
 
 #### Build & Install
 
@@ -33,30 +33,22 @@ sudo sh -c "echo 'deb https://packagecloud.io/timescale/timescaledb/debian/ `lsb
 wget --quiet -O - https://packagecloud.io/timescale/timescaledb/gpgkey | sudo apt-key add -
 sudo apt-get update
 
-# To install for PG 10.2+
-sudo apt-get install timescaledb-postgresql-10
-# To install for PG 9.6.3+
-sudo apt-get install timescaledb-postgresql-9.6
-
-# PG 11 support is currently in BETA. To install for PG 11.0+
-sudo apt-get install timescaledb-postgresql-11
+# Now install appropriate package for PG version
+sudo apt-get install timescaledb-postgresql-:pg_version:
 ```
 
 #### Update `postgresql.conf`
 
 >:TIP: The usual location of `postgres.conf`
-is `/etc/postgresql/9.6/main/postgresql.conf` for 9.6 and
-`/etc/postgresql/10/main/postgresql.conf` for 10, but this may vary
+is `/etc/postgresql/:pg_version:/main/postgresql.conf`, but this may vary
 depending on your setup. If you are unsure where your `postgresql.conf` file
-is located, you can query PostgreSQL through the psql interface using `SHOW config_file;`.
-Please note that you must have created a `postgres` superuser so that you can access the psql
-interface.
+is located, you can query PostgreSQL with any database client (e.g., `psql`)
+using `SHOW config_file;`.
 
 You will need to edit your `postgresql.conf` file to include
 necessary libraries:
 ```bash
 # Modify postgresql.conf to uncomment this line and add required libraries.
-# For example:
 shared_preload_libraries = 'timescaledb'
 ```
 

--- a/getting-started/installation-apt-ubuntu.md
+++ b/getting-started/installation-apt-ubuntu.md
@@ -34,30 +34,22 @@ any dependencies it needs from the PostgreSQL repo):
 sudo add-apt-repository ppa:timescale/timescaledb-ppa
 sudo apt-get update
 
-# To install for PG 10.2+
-sudo apt install timescaledb-postgresql-10
-# To install for PG 9.6.3+
-sudo apt install timescaledb-postgresql-9.6
-
-# PG 11 support is currently in BETA. To install for PG 11.0+
-sudo apt install timescaledb-postgresql-11
+# Now install appropriate package for PG version
+sudo apt install timescaledb-postgresql-:pg_version:
 ```
 
 #### Update `postgresql.conf`
 
 >:TIP: The usual location of `postgres.conf`
-is `/etc/postgresql/9.6/main/postgresql.conf` for 9.6 and
-`/etc/postgresql/10/main/postgresql.conf` for 10, but this may vary
+is `/etc/postgresql/:pg_version:/main/postgresql.conf`, but this may vary
 depending on your setup. If you are unsure where your `postgresql.conf` file
-is located, you can query PostgreSQL through the psql interface using `SHOW config_file;`.
-Please note that you must have created a `postgres` superuser so that you can access the psql
-interface.
+is located, you can query PostgreSQL with any database client (e.g., `psql`)
+using `SHOW config_file;`.
 
 You will need to edit your `postgresql.conf` file to include
 necessary libraries:
 ```bash
 # Modify postgresql.conf to uncomment this line and add required libraries.
-# For example:
 shared_preload_libraries = 'timescaledb'
 ```
 

--- a/getting-started/installation-docker.md
+++ b/getting-started/installation-docker.md
@@ -2,30 +2,31 @@
 
 #### Quick start
 
-Starting a TimescaleDB instance, pulling our Docker image from [Docker Hub][] if it has not been already installed.
+Start a TimescaleDB instance, pulling our Docker image from [Docker Hub][] if it has not been already installed:
 
 ```bash
-docker run -d --name timescaledb -p 5432:5432 -e POSTGRES_PASSWORD=password timescale/timescaledb
+docker run -d --name timescaledb -p 5432:5432 -e POSTGRES_PASSWORD=password timescale/timescaledb:latest-pg:pg_version:
 ```
 
 >:WARNING: The -p flag binds the container port to the host port, meaning
 anything that can access the host port will be able to access your TimescaleDB
 container. This can be particularly dangerous if you do not set a PostgreSQL
 password at runtime using the `POSTGRES_PASSWORD` environment variable as we
-do in the above command. Without that variable, the Docker container will disable
-password checks for all database users. If you want to access the container
-from the host but avoid exposing it to the outside world, you can explicitly
-have it bind to 127.0.0.1 instead of the public interface by using
+do in the above command. Without that variable, the Docker container will
+disable password checks for all database users. If you want to access the
+container from the host but avoid exposing it to the outside world, you can
+explicitly have it bind to 127.0.0.1 instead of the public interface by using
 `-p 127.0.0.1:5432:5432`.
 >
 >Otherwise, you'll want to ensure that your host box is adequately locked down
-through security groups, IP Tables, or whatever you're using for acccess control.
-Note also that Docker binds the container by modifying your Linux IP Tables.
-For systems that use Linux UFW (Uncomplicated Firewall) for security rules,
-this means that Docker will potentially override any UFW settings that restrict
-the port you are binding to. If you are relying on UFW rules for network
-security, consider adding `DOCKER_OPTS="--iptables=false"` to `/etc/default/docker`
-to prevent Docker from overwriting IP Tables. See [this writeup on the vulnerability][docker-vulnerability]
+through security groups, IP Tables, or whatever you're using for access
+control. Note also that Docker binds the container by modifying your Linux IP
+Tables. For systems that use Linux UFW (Uncomplicated Firewall) for security
+rules, this means that Docker will potentially override any UFW settings that
+restrict the port you are binding to. If you are relying on UFW rules for
+network security, consider adding `DOCKER_OPTS="--iptables=false"` to
+`/etc/default/docker` to prevent Docker from overwriting IP Tables.
+See [this writeup on the vulnerability][docker-vulnerability]
 for more details.
 
 If you have PostgreSQL client tools (e.g., `psql`) installed locally,
@@ -40,18 +41,14 @@ docker exec -it timescaledb psql -U postgres
 
 #### More detailed instructions
 
-Our Docker image is derived from the [official PostgreSQL image][official-image] and
-includes [alpine Linux][] as its OS.
+Our Docker image is derived from the [official PostgreSQL image][official-image]
+and includes [alpine Linux][] as its OS.
 
 While the above `run` command will pull the Docker image on demand,
 you can also -- and for upgrades, **need to** -- explicitly pull our image from [Docker Hub][]:
 
 ```bash
-docker pull timescale/timescaledb:latest-pg10  # for PostgreSQL 10
-docker pull timescale/timescaledb:latest-pg9.6 # for PostgreSQL 9.6
-
-# PG 11 support is currently in BETA
-docker pull timescale/timescaledb:latest-pg11  # for PostgreSQL 11
+docker pull timescale/timescaledb:latest-pg:pg_version:
 ```
 
 When running a Docker image, if one prefers to store the data in a

--- a/getting-started/installation-homebrew.md
+++ b/getting-started/installation-homebrew.md
@@ -31,10 +31,9 @@ brew install timescaledb
 
 >:TIP: The usual location of `postgresql.conf` is
 `/usr/local/var/postgres/postgresql.conf`, but this may vary depending on
-your setup. If you are unsure where your `postgresql.conf` file is located, you
-can query PostgreSQL through the psql interface using `SHOW config_file;`. Please note
-that you must have created a `postgres` superuser so that you can access the psql
-interface.
+your setup. If you are unsure where your `postgresql.conf` file
+is located, you can query PostgreSQL with any database client (e.g., `psql`)
+using `SHOW config_file;`.
 
 Also, you will need to edit your `postgresql.conf` file to include
 necessary libraries:
@@ -49,8 +48,9 @@ shared_preload_libraries = 'timescaledb'
 
 To get started you'll now need to restart PostgreSQL and add
 a `postgres` superuser (used in the rest of the docs):
->:WARNING: If you are still on PostgreSQL 9.6 via Homebrew, you should
-replace `postgresql` with <code>postgresql&#64;9.6</code>.
+>:WARNING: If you are still on PostgreSQL 9.6 or 10 via Homebrew, you should
+replace `postgresql` with <code>postgresql&#64;9.6</code> for 9.6 or
+<code>postgresql&#64;10</code> for 10.
 
 ```bash
 # Restart PostgreSQL instance

--- a/getting-started/installation-source-windows.md
+++ b/getting-started/installation-source-windows.md
@@ -7,7 +7,7 @@
 - A standard **PostgreSQL 9.6 or 10 64-bit** installation
 - Visual Studio 2017 (with [CMake][] and Git components)  
   **or** Visual Studio 2015/2016 (with [CMake][] version 3.4+ and Git components)
-- Make sure all relevant binaries are in your PATH: `pg_config`, `cmake`, `MSBuild`
+- Make sure all relevant binaries are in your PATH: `pg_config` and `cmake`
 
 #### Build & Install with Local PostgreSQL
 >:TIP: It is **highly recommended** that you checkout the latest
@@ -28,14 +28,13 @@ care of the rest.
 If you are using an earlier version of Visual Studio:
 ```bash
 # Bootstrap the build system
-./bootstrap.bat
+bootstrap.bat
 
 # To build the extension from command line
-cd build
-MSBuild.exe timescaledb.sln
+cmake --build ./build --config Release
 
 # To install
-MSBuild.exe /p:Configuration=Release INSTALL.vcxproj
+cmake --build ./build --config Release --target install
 
 # Alternatively, open build/timescaledb.sln in Visual Studio and build,
 # then open & build build/INSTALL.vcxproj

--- a/getting-started/installation-windows.md
+++ b/getting-started/installation-windows.md
@@ -10,7 +10,7 @@
 
 #### Build & Install
 
-1. Download the the .zip file for your PostgreSQL version: [PostgreSQL 9.6][windows-dl-pg9.6] or [PostgreSQL 10][windows-dl-pg10]
+1. Download the the [.zip file for your PostgreSQL version][windows-dl].
 
 1. Extract the zip file locally
 
@@ -26,8 +26,9 @@ Go ahead and press ENTER to close the window
 
 #### Update `postgresql.conf`
 
-You will need to edit your `postgresql.conf` file to include
-necessary libraries, and then restart PostgreSQL. First, locate your postgresql.conf file:
+You will need to edit your `postgresql.conf` file to include necessary
+libraries, and then restart PostgreSQL. First, locate your `postgresql.conf`
+file:
 
 ```bash
 psql -d postgres -c "SHOW config_file;"
@@ -46,5 +47,4 @@ Then, restart the PostgreSQL instance.
 
 [c_plus]: https://www.microsoft.com/en-us/download/details.aspx?id=48145
 [pg_config]: https://www.postgresql.org/docs/10/static/app-pgconfig.html
-[windows-dl-pg9.6]:  https://timescalereleases.blob.core.windows.net/windows/timescaledb-postgresql-9.6_x.y.z-windows-amd64.zip
-[windows-dl-pg10]: https://timescalereleases.blob.core.windows.net/windows/timescaledb-postgresql-10_x.y.z-windows-amd64.zip
+[windows-dl]:  https://timescalereleases.blob.core.windows.net/windows/timescaledb-postgresql-:pg_version:_x.y.z-windows-amd64.zip

--- a/getting-started/installation-yum.md
+++ b/getting-started/installation-yum.md
@@ -7,8 +7,7 @@ This will install both TimescaleDB *and* PostgreSQL via `yum`
 
 #### Prerequisites
 
-- Fedora 24 or later, or
-- CentOS 7 or later
+- CentOS 7 (or Fedora/RHEL equivalent) or later
 
 #### Build & Install
 
@@ -31,13 +30,8 @@ Further setup instructions [are found here][yuminstall].
 
 Then, fetch our RPM and install it:
 ```bash
-# Fetch our RPM (for PostgreSQL 9.6)
-wget https://timescalereleases.blob.core.windows.net/rpm/timescaledb-x.y.z-postgresql-9.6-0.x86_64.rpm
-# For PostgreSQL 10:
-wget https://timescalereleases.blob.core.windows.net/rpm/timescaledb-x.y.z-postgresql-10-0.x86_64.rpm
-
-# For PostgreSQL 11. PG 11 support is currently in BETA:
-wget https://timescalereleases.blob.core.windows.net/rpm/timescaledb-x.y.z-postgresql-11-0.x86_64.rpm
+# Fetch our RPM
+wget https://timescalereleases.blob.core.windows.net/rpm/timescaledb-x.y.z-postgresql-:pg_version:-0.x86_64.rpm
 
 # To install
 sudo yum install <name of file you downloaded with wget>
@@ -45,19 +39,16 @@ sudo yum install <name of file you downloaded with wget>
 
 #### Update `postgresql.conf`
 
->:TIP: The usual location of `postgres.conf`
-is `/var/lib/pgsql/9.6/data/postgresql.conf` for PostgreSQL 9.6
-and `/var/lib/pgsql/10/data/postgresql.conf` for PostgreSQL 10,
-but this may vary depending on your setup. If you are unsure where your `postgresql.conf` file
-is located, you can query PostgreSQL through the psql interface using `SHOW config_file;`.
-Please note that you must have created a `postgres` superuser so that you can access the psql
-interface.
+>:TIP: The usual location of `postgres.conf` is
+`/var/lib/pgsql/:pg_version:/data/postgresql.conf`, but this may vary depending
+on your setup. If you are unsure where your `postgresql.conf` file
+is located, you can query PostgreSQL with any database client (e.g., `psql`)
+using `SHOW config_file;`.
 
 You will need to edit your `postgresql.conf` file to include
 necessary libraries:
 ```bash
 # Modify postgresql.conf to uncomment this line and add required libraries.
-# For example:
 shared_preload_libraries = 'timescaledb'
 ```
 


### PR DESCRIPTION
The macro :pg-version: allows us to dynamically change links and
commands based on the user selected version of PostgreSQL so we
don't have to provide every alternative in each page.

Also further cleanups done to instructions to remove superfluous
language, outdated versions (e.g. Debian 7), and outdated
instructions (Windows source).