### PR TITLE
Improve notation of link in the in the Hello NYC tutorial

### DIFF
--- a/tutorials/tutorial-hello-nyc.md
+++ b/tutorials/tutorial-hello-nyc.md
@@ -34,7 +34,9 @@ CREATE DATABASE nyc_data;
 CREATE EXTENSION IF NOT EXISTS timescaledb CASCADE;
 ```
 
-Now, download the file [`nyc_data.tar.gz`][nyc_data].
+Next, download the file from the below link:
+
+[:DOWNLOAD_LINK: `nyc_data.tar.gz`][nyc_data]
 
 Then, follow these steps:
 


### PR DESCRIPTION
Dear developers.

In my opinion, we easily overlook a link of sample data (e nyc_data.tar.gz).
Because this link within backquote, it is treated as inline code and we don't look like a link.

So, would it be possible to separate a link as in this PR.