### PR TITLE
Fix statements that partitions must be prefixes of UNIQUE

### DIFF
--- a/using-timescaledb/schema-management.md
+++ b/using-timescaledb/schema-management.md
@@ -115,13 +115,11 @@ matching your predicate, but in each one, your query also grabs a
 (potentially large) subset of the values, rather than just one
 distinct one.
 
->:TIP: [](unique_indexes) To a define an index as UNIQUE or PRIMARY KEY, the time column and, if it
-exists, the partitioning column **must** be the first (or first two)
-columns that comprise the index.  That is, using our running
-example, you can define a unique index on just the {time, location} fields,
-or to include a third column (say, temperature), the index
-must be specified as {time, location, temperature}.  That said, we
-find UNIQUE indexes in time-series data to be much less prevalent than
+>:TIP: [](unique_indexes) To define an index as UNIQUE or PRIMARY KEY, the time column and, if it
+exists, the partitioning column **must** be part of the index.
+That is, using our running example, you can define a unique index on just the
+{time, location} fields, or to include additional columns (say, temperature).
+That said, we find UNIQUE indexes in time-series data to be much less prevalent than
 in traditional relational data models.
 
 

--- a/using-timescaledb/writing-data.md
+++ b/using-timescaledb/writing-data.md
@@ -148,10 +148,10 @@ INSERT INTO conditions
         humidity = excluded.humidity;
 ```
 
->:TIP: Unique constraints must include all partitioning keys as
- their prefix.  For example, if the table just uses time partitioning,
- the system requires `time` as the initial part of the
- constraint: `UNIQUE(time)`, `UNIQUE(time, location)`, etc.
+>:TIP: Unique constraints must include all partitioning keys.
+ For example, if the table just uses time partitioning,
+ the system requires `time` as part of the
+ constraint: `UNIQUE(time)`, `UNIQUE(time, location)`, `UNIQUE(location, time)`, etc.
  On the other hand, `UNIQUE(location)` is *not* a valid constraint.
 >
 >If the schema were to have an additional column like `device` that is used


### PR DESCRIPTION
Partitions have to be part of a unique index but it is not
necessary for them to be in the prefix. Fix language to reflect
that.