### PR TITLE
Fix embedded license key info indentation

### DIFF
--- a/using-timescaledb/telemetry.md
+++ b/using-timescaledb/telemetry.md
@@ -9,12 +9,12 @@ the JSON that is sent to our servers about a specific deployment:
 {
 	"db_uuid": "26917841-2fc0-48fd-b096-ba19b3fda98f",
 	"license": {
-        "id": "490FB260-A292-4AD9-9AA2-0360835791B8",
-        "kind": "trial",
-        "edition": "enterprise",
-        "end_time": "2018-09-30 20:00:00-04",
-        "start_time": "2018-08-31 20:00:00-04"
-    },
+		"id": "490FB260-A292-4AD9-9AA2-0360835791B8",
+		"kind": "trial",
+		"edition": "enterprise",
+		"end_time": "2018-09-30 20:00:00-04",
+		"start_time": "2018-08-31 20:00:00-04"
+	},
 	"exported_db_uuid": "8dd4543c-f44e-43c9-a666-02d23bb09b90",
 	"installed_time": "2000-04-17 10:56:59.427738-04",
 	"last_tuned_time": "2001-02-03T04:05:06-0300",


### PR DESCRIPTION
Current telemetry example indentation improperly deals with inner bracket. This fixes the formatting of that example.