### PR TITLE
Add section on timescaledb-tune to Configuration

### DIFF
--- a/getting-started/configuring.md
+++ b/getting-started/configuring.md
@@ -1,13 +1,78 @@
 # Configuring TimescaleDB
 
 TimescaleDB works with the default PostgreSQL server configuration settings.
-However, we find that optimizing some settings increases performance. These
-settings can be adjusted in your machine's `postgresql.conf`.
+However, we find that these settings are typically too conservative and
+can be limiting when using larger servers with more resources (CPU, memory,
+disk, etc). Adjusting these settings, either
+[automatically with our tool `timescaledb-tune`][tstune] or manually editing
+your machine's `postgresql.conf`, can improve performance.
 
->:TIP: You can determine the location of `postgresql.conf` by running `SHOW config_file;`
-from within psql.
+>:TIP: You can determine the location of `postgresql.conf` by running
+`SHOW config_file;` from your PostgreSQL client (e.g., `psql`).
 
-## Memory settings [](memory)
+## Recommended: `timescaledb-tune` [](ts-tune)
+
+To streamline the configuration process, we've created a tool called
+[`timescaledb-tune`][tstune] that handles setting the most common parameters to
+good values based on your system, accounting for memory, CPU, and PostgreSQL
+version. `timescaledb-tune` is packaged along with our binary releases as
+a dependency, so if you installed one of our binary releases (including
+Docker), you should have access to the tool. Alternatively, with a standard
+Go environment, you can also `go get` the repository to install it.
+
+`timescaledb-tune` reads your system's `postgresql.conf` file and offers
+interactive suggestions for updating your settings:
+```text
+Using postgresql.conf at this path:
+/usr/local/var/postgres/postgresql.conf
+
+Is this correct? [(y)es/(n)o]: y
+Writing backup to:
+/var/folders/cr/zpgdkv194vz1g5smxl_5tggm0000gn/T/timescaledb_tune.backup201901071520
+
+shared_preload_libraries needs to be updated
+Current:
+#shared_preload_libraries = 'timescaledb'
+Recommended:
+shared_preload_libraries = 'timescaledb'
+Is this okay? [(y)es/(n)o]: y
+success: shared_preload_libraries will be updated
+
+Tune memory/parallelism/WAL and other settings? [(y)es/(n)o]: y
+Recommendations based on 8.00 GB of available memory and 4 CPUs for PostgreSQL 11
+
+Memory settings recommendations
+Current:
+shared_buffers = 128MB
+#effective_cache_size = 4GB
+#maintenance_work_mem = 64MB
+#work_mem = 4MB
+Recommended:
+shared_buffers = 2GB
+effective_cache_size = 6GB
+maintenance_work_mem = 1GB
+work_mem = 26214kB
+Is this okay? [(y)es/(s)kip/(q)uit]:
+```
+
+These changes are then written to your `postgresql.conf` and will take effect
+on the next (re)start. If you are starting on fresh instance and don't feel
+the need to approve each group of changes, you can also automatically accept
+and append the suggestions to the end of your `postgresql.conf` like so:
+```bash
+$ timescaledb-tune --quiet --yes --dry-run >> /path/to/postgresql.conf
+```
+
+## Further configuration / manual tuning [](further-config)
+
+If you prefer to tune the settings yourself, or are curious about the
+suggestions that `timescaledb-tune` comes up with, we elaborate on them
+here. Additionally, `timescaledb-tune` does not cover all settings you
+may need to adjust; those are covered below.
+
+### Memory settings [](memory)
+
+>:TIP: All of these settings are handled by `timescaledb-tune`.
 
 The settings `shared_buffers`, `effective_cache_size`, `work_mem`, and
 `maintenance_work_mem` need to be adjusted to match the machine's available
@@ -17,7 +82,9 @@ website (suggested DB Type: Data warehouse). You should also adjust the
 connection between `max_connections` and memory settings. Other settings from
 PgTune may also be helpful.
 
-## Worker settings [](workers)
+### Worker settings [](workers)
+
+>:TIP: All of these settings are handled by `timescaledb-tune`.
 
 PostgreSQL utilizes worker pools to provide the required workers needed to
 support both live queries and background jobs. If you do not configure these
@@ -44,18 +111,19 @@ Finally, you must configure `max_worker_processes` to be at least the sum of
 background and parallel workers (as well as a handful of built-in PostgreSQL
 workers).
 
-## Disk-write settings [](disk-write)
+### Disk-write settings [](disk-write)
 
 In order to increase write throughput, there are [multiple
-settings][async-commit] to adjust the behaviour that PostgreSQL uses to write data
-to disk. We find the performance to be good with the default (safest) settings. If
-you want a bit of additional performance, you can  set `synchronous_commit =
-'off'`([PostgreSQL docs][synchronous-commit]). Please note that when disabling
+settings][async-commit] to adjust the behavior that PostgreSQL uses to write
+data to disk. We find the performance to be good with the default (safest)
+settings. If you want a bit of additional performance, you can set
+`synchronous_commit = 'off'`([PostgreSQL docs][synchronous-commit]).
+Please note that when disabling
 `sychronous_commit` in this way, an operating system or database crash might
 result in some recent allegedly-committed transactions being lost. We actively
 discourage changing the `fsync` setting.
 
-## Lock settings [](locks)
+### Lock settings [](locks)
 
 TimescaleDB relies heavily on table partitioning for scaling
 time-series workloads, which has implications for [lock
@@ -91,7 +159,7 @@ locks allocated for each transaction. For more information, please
 review the official PostgreSQL documentation on
 [lock management][lock-management].
 
-## Changing configuration with Docker
+### Changing configuration with Docker [](config-docker)
 
 When running TimescaleDB via a [Docker container][docker], there are
 two approaches to modifying your PostgreSQL configuration.  In the
@@ -99,7 +167,7 @@ following example, we modify the size of the database instance's
 write-ahead-log (WAL) from 1GB to 2GB in a Docker container named
 `timescaledb`.
 
-### Modifying postgres.conf inside Docker
+#### Modifying postgres.conf inside Docker
 
 1. Get into a shell in Docker in order to change the configuration on a running container.
 ```
@@ -127,16 +195,19 @@ docker restart timescaledb
     2GB
 ```
 
-### Specify config parameters as boot options
+#### Specify config parameters as boot options
 
-Alternatively, one or more parameters can be passed in to the `docker run` command via a `-c` option, as in the following.
+Alternatively, one or more parameters can be passed in to the `docker run`
+command via a `-c` option, as in the following.
 
 ```
 docker run -i -t timescale/timescaledb:latest-pg10 postgres -cmax_wal_size=2GB
 ```
 
-Additional examples of passing in arguments at boot can be found in our [discussion about using WAL-E][wale] for incremental backup.
+Additional examples of passing in arguments at boot can be found in our
+[discussion about using WAL-E][wale] for incremental backup.
 
+[tstune]: https://github.com/timescale/timescaledb-tune
 [pgtune]: http://pgtune.leopard.in.ua/
 [async-commit]: https://www.postgresql.org/docs/current/static/wal-async-commit.html
 [synchronous-commit]: https://www.postgresql.org/docs/current/static/runtime-config-wal.html#GUC-SYNCHRONOUS-COMMIT


### PR DESCRIPTION
Given that timescaledb-tune will handle many of the options we
suggest configuring, we add a section on using it to the Configuration
page so users can find it easily. The Configuration page is therefore
reorganized into two large sections for automatic tuning and further
explanation/manual tuning.