### PR TITLE
Include enterprise license key in getting started

### DIFF
--- a/api.md
+++ b/api.md
@@ -23,6 +23,8 @@
 > - [set_chunk_time_interval](#set_chunk_time_interval)
 > - [set_number_partitions](#set_number_partitions)
 > - [timescaledb_information.hypertable](#timescaledb_information-hypertable)
+> - [timescaledb_information.license](#timescaledb_information-license)
+> - [timescaledb.license_key](#timescaledb_license-key)
 > - [show_chunks](#show_chunks)
 > - [show_tablespaces](#show_tablespaces)
 > - [time_bucket](#time_bucket)
@@ -1114,6 +1116,40 @@ SELECT * FROM timescaledb_information.hypertable WHERE table_schema='public' AND
 --------------+------------+-------------+----------------+------------+------------+------------+------------+------------
  public       | metrics    | postgres    |              1 |          5 | 99 MB      | 96 MB      |            | 195 MB
 (1 row)
+```
+
+## timescaledb_information.license [](timescaledb_information-license)
+
+Get information about current license.
+
+#### Available Columns
+
+|Name|Description|
+|---|---|
+| `edition` | License key type (apache_only, community, enterprise) |
+| `expired` | Expiration status of license key (bool) |
+| `expiration_time` | Time of license key expiration |
+
+#### Sample Usage
+
+Get information about current license.
+
+```sql
+SELECT * FROM timescaledb_information.license;
+edition   | expired |    expiration_time
+------------+---------+------------------------
+enterprise | f       | 2019-02-15 13:44:53-05
+(1 row)
+```
+
+## timescaledb.license_key [](timescaledb_license-key)
+
+#### Sample Usage
+
+View current license key.
+
+```sql 
+SHOW timescaledb.license_key;
 ```
 
 ## chunk_relation_size() [](chunk_relation_size)

--- a/getting-started/exploring-enterprise.md
+++ b/getting-started/exploring-enterprise.md
@@ -1,0 +1,62 @@
+# Exploring TimescaleDB Enterprise
+
+TimescaleDB currently offers three product lines: OSS, Community, and Enterprise. 
+The Enterprise offering features automated data management that enables hands-free data retention policies 
+and data re-ordering on disk. For an overview of how TimescaleDB product lines differ, 
+please take a look at our [Pricing][pricing] page.
+
+## Requesting a License Key
+
+It is easy to get started with TimescaleDB Enterprise. In fact, if you are already 
+running TimescaleDB Community, all you have to do is obtain a license key to unlock 
+all Enterprise capabilities. No software upgrade or downgrade is required. We offer a free 30-day license 
+that you can request [online][license]. The license will be sent to you via email. 
+
+To upgrade or obtain a full Enterprise license key, please [contact sales][contact-sales].
+
+## Activating TimescaleDB Enterprise
+
+Before you can activate TimescaleDB Enterprise, you must have a Timescale-Licensed version of 
+TimescaleDB up and running. Note that our standard binary releases are by default Timescale-Licensed. 
+
+>:WARNING: If you explicitly built or downloaded an Apache 2.0 binary, you will not be able to 
+directly activate TimescaleDB Enterprise. You must upgrade to a Timescale-Licensed binary first. 
+Please note that this also applies to any TimescaleDB versions prior to v1.2.0.
+
+>:TIP: You can also set your license key prior to starting TimescaleDB by including 
+`timescaledb.license_key = '<license_key>'` in your `postgresql.conf` file. 
+The usual location of `postgresql.conf` is `/usr/local/var/postgres/postgresql.conf`, 
+but this may vary depending on your setup. If you are unsure where your `postgresql.conf` file
+is located, you can query PostgreSQL with any database client (e.g., `psql`)
+using `SHOW config_file;`.
+
+First connect to the PostgreSQL instance:
+
+```bash
+# Connect to PostgreSQL, using a superuser named 'postgres'
+psql -U postgres -h localhost
+```
+
+Next, input the license key you received via email:
+
+```sql
+ALTER SYSTEM SET timescaledb.license_key='<license_key';
+
+-- Reload your PostgreSQL configs
+SELECT pg_reload_conf();
+```
+
+Now make sure that your license key was set correctly:
+
+```sql
+SELECT * FROM timescaledb_information.license;
+```
+
+You'll be able to use the above command to check your license type and license expiration date.
+
+Continue exploring our enterprise features in our API docs.
+
+
+[pricing]: https://www.timescale.com/pricing
+[license]: https://www.timescale.com/license
+[contact-sales]: https://www.timescale.com/contact


### PR DESCRIPTION
This includes information on how to input and request a license key when a user is getting started. It also modifies the API docs with some helper functions relevant to the license key flow. 

When enterprise feature docs are out, we can update this flow with links to the relevant API docs.

@solugebefola this adds a new page, so the index will need to be recreated.