### PR TITLE
Add tip about building OSS-only binaries

### DIFF
--- a/getting-started/exploring-enterprise.md
+++ b/getting-started/exploring-enterprise.md
@@ -17,7 +17,7 @@ To upgrade or obtain a full Enterprise license key, please [contact sales][conta
 ## Activating TimescaleDB Enterprise
 
 Before you can activate TimescaleDB Enterprise, you must have a Timescale-Licensed version of 
-TimescaleDB up and running. Note that our standard binary releases are by default Timescale-Licensed. 
+TimescaleDB up and running. Note, the standard binaries we make available are released under the Timescale License. 
 
 >:WARNING: If you explicitly built or downloaded an Apache 2.0 binary, you will not be able to 
 directly activate TimescaleDB Enterprise. You must upgrade to a Timescale-Licensed binary first. 

--- a/getting-started/installation-apt-debian.md
+++ b/getting-started/installation-apt-debian.md
@@ -61,6 +61,14 @@ a `postgres` superuser (used in the rest of the docs):
 sudo service postgresql restart
 ```
 
+>:TIP: Our standard binary releases are licensed under the Timescale License. This means that you can use all of our free Community capabilities and seamlessly 
+activate Enterprise capabilities.  
+To build a version of this software that contains 
+source code that is only licensed under Apache License 2.0, pass `-DAPACHE_ONLY=1` 
+to `bootstrap`.   
+For more information about licensing, please read our [blog post][blog-post] about the subject.
+
 [Here are some instructions to create the `postgres` superuser][createuser].
 
 [createuser]: http://suite.opengeo.org/docs/latest/dataadmin/pgGettingStarted/firstconnect.html
+[blog-post]: https://blog.timescale.com/how-we-are-building-an-open-source-business-a7701516a480

--- a/getting-started/installation-apt-ubuntu.md
+++ b/getting-started/installation-apt-ubuntu.md
@@ -62,7 +62,15 @@ a `postgres` superuser (used in the rest of the docs):
 sudo service postgresql restart
 ```
 
+>:TIP: Our standard binary releases are licensed under the Timescale License. This means that you can use all of our free Community capabilities and seamlessly 
+activate Enterprise capabilities.  
+To build a version of this software that contains 
+source code that is only licensed under Apache License 2.0, pass `-DAPACHE_ONLY=1` 
+to `bootstrap`.   
+For more information about licensing, please read our [blog post][blog-post] about the subject.
+
 [Here are some instructions to create the `postgres` superuser][createuser].
 
 [createuser]: http://suite.opengeo.org/docs/latest/dataadmin/pgGettingStarted/firstconnect.html
 [ubuntu-releases]: http://releases.ubuntu.com/
+[blog-post]: https://blog.timescale.com/how-we-are-building-an-open-source-business-a7701516a480

--- a/getting-started/installation-docker.md
+++ b/getting-started/installation-docker.md
@@ -68,6 +68,13 @@ until explicitly removed. Use `docker volume ls` to list the existing
 docker volumes.
 ([More information on data volumes][docker-data-volumes])
 
+>:TIP: Our standard binary releases are licensed under the Timescale License. This means that you can use all of our free Community capabilities and seamlessly 
+activate Enterprise capabilities.  
+To build a version of this software that contains 
+source code that is only licensed under Apache License 2.0, pass `-DAPACHE_ONLY=1` 
+to `bootstrap`.   
+For more information about licensing, please read our [blog post][blog-post] about the subject.
+
 ## Prebuilt with PostGIS [](postgis-docker)
 
 We have also published a Docker image that comes prebuilt with
@@ -106,3 +113,4 @@ For more instructions on using our Prometheus adapter, [see our tutorial][tutori
 [tutorial-prometheus]: /tutorials/prometheus-adapter
 [adapter-github]: https://github.com/timescale/prometheus-postgresql-adapter
 [prometheus-extension]: https://github.com/timescale/pg_prometheus
+[blog-post]: https://blog.timescale.com/how-we-are-building-an-open-source-business-a7701516a480

--- a/getting-started/installation-homebrew.md
+++ b/getting-started/installation-homebrew.md
@@ -59,4 +59,13 @@ brew services restart postgresql
 # Add a superuser postgres:
 createuser postgres -s
 ```
+
+>:TIP: Our standard binary releases are licensed under the Timescale License. This means that you can use all of our free Community capabilities and seamlessly 
+activate Enterprise capabilities.  
+To build a version of this software that contains 
+source code that is only licensed under Apache License 2.0, pass `-DAPACHE_ONLY=1` 
+to `bootstrap`.   
+For more information about licensing, please read our [blog post][blog-post] about the subject.
+
 [Homebrew]: https://brew.sh/
+[blog-post]: https://blog.timescale.com/how-we-are-building-an-open-source-business-a7701516a480

--- a/getting-started/installation-source-windows.md
+++ b/getting-started/installation-source-windows.md
@@ -60,6 +60,14 @@ shared_preload_libraries = 'timescaledb'
 
 Then, restart the PostgreSQL instance.
 
+>:TIP: Our standard binary releases are licensed under the Timescale License. This means that you can use all of our free Community capabilities and seamlessly 
+activate Enterprise capabilities.  
+To build a version of this software that contains 
+source code that is only licensed under Apache License 2.0, pass `-DAPACHE_ONLY=1` 
+to `bootstrap`.   
+For more information about licensing, please read our [blog post][blog-post] about the subject.
+
 [CMake]: https://cmake.org/
 [github-timescale]: https://github.com/timescale/timescaledb
 [github-releases]: https://github.com/timescale/timescaledb/releases
+[blog-post]: https://blog.timescale.com/how-we-are-building-an-open-source-business-a7701516a480

--- a/getting-started/installation-source.md
+++ b/getting-started/installation-source.md
@@ -53,6 +53,14 @@ shared_preload_libraries = 'timescaledb'
 
 Then, restart the PostgreSQL instance.
 
+>:TIP: Our standard binary releases are licensed under the Timescale License. This means that you can use all of our free Community capabilities and seamlessly 
+activate Enterprise capabilities.  
+To build a version of this software that contains 
+source code that is only licensed under Apache License 2.0, pass `-DAPACHE_ONLY=1` 
+to `bootstrap`.   
+For more information about licensing, please read our [blog post][blog-post] about the subject.
+
 [CMake]: https://cmake.org/
 [github-timescale]: https://github.com/timescale/timescaledb
 [github-releases]: https://github.com/timescale/timescaledb/releases
+[blog-post]: https://blog.timescale.com/how-we-are-building-an-open-source-business-a7701516a480

--- a/getting-started/installation-windows.md
+++ b/getting-started/installation-windows.md
@@ -45,6 +45,14 @@ shared_preload_libraries = 'timescaledb'
 
 Then, restart the PostgreSQL instance.
 
+>:TIP: Our standard binary releases are licensed under the Timescale License. This means that you can use all of our free Community capabilities and seamlessly 
+activate Enterprise capabilities.  
+To build a version of this software that contains 
+source code that is only licensed under Apache License 2.0, pass `-DAPACHE_ONLY=1` 
+to `bootstrap`.   
+For more information about licensing, please read our [blog post][blog-post] about the subject.
+
 [c_plus]: https://www.microsoft.com/en-us/download/details.aspx?id=48145
 [pg_config]: https://www.postgresql.org/docs/10/static/app-pgconfig.html
 [windows-dl]:  https://timescalereleases.blob.core.windows.net/windows/timescaledb-postgresql-:pg_version:_x.y.z-windows-amd64.zip
+[blog-post]: https://blog.timescale.com/how-we-are-building-an-open-source-business-a7701516a480

--- a/getting-started/installation-yum.md
+++ b/getting-started/installation-yum.md
@@ -59,6 +59,14 @@ a `postgres` superuser (used in the rest of the docs). Please
 refer to your distribution for how to restart services and
 [these instructions for adding a `postgres` user][createuser].
 
+>:TIP: Our standard binary releases are licensed under the Timescale License. This means that you can use all of our free Community capabilities and seamlessly 
+activate Enterprise capabilities.  
+To build a version of this software that contains 
+source code that is only licensed under Apache License 2.0, pass `-DAPACHE_ONLY=1` 
+to `bootstrap`.   
+For more information about licensing, please read our [blog post][blog-post] about the subject.
+
 [createuser]: http://suite.opengeo.org/docs/latest/dataadmin/pgGettingStarted/firstconnect.html
 [pgdg]: https://yum.postgresql.org/repopackages.php
 [yuminstall]: https://wiki.postgresql.org/wiki/YUM_Installation
+[blog-post]: https://blog.timescale.com/how-we-are-building-an-open-source-business-a7701516a480


### PR DESCRIPTION
This adds a tip that clarifies that binaries are by default TSL. If we decide to build OSS specific binaries, we can update this tip to point towards a different landing page that is organized elsewhere.