### PR TITLE
Remove Postgres requirement note

### DIFF
--- a/getting-started/installation-apt-debian.md
+++ b/getting-started/installation-apt-debian.md
@@ -2,8 +2,6 @@
 
 This will install TimescaleDB via `apt` on Debian distros.
 
-**Note: TimescaleDB requires PostgreSQL 9.6.3+, 10.2+, or 11.0+**
-
 #### Prerequisites
 
 - Debian 8 (jessie) or 9 (stretch)
@@ -61,10 +59,10 @@ a `postgres` superuser (used in the rest of the docs):
 sudo service postgresql restart
 ```
 
->:TIP: Our standard binary releases are licensed under the Timescale License. This means that you can use all of our free Community capabilities and seamlessly 
+>:TIP: Our standard binary releases are licensed under the Timescale License. This means that you can use all of our free Community capabilities and seamlessly
 activate Enterprise capabilities.  
-To build a version of this software that contains 
-source code that is only licensed under Apache License 2.0, pass `-DAPACHE_ONLY=1` 
+To build a version of this software that contains
+source code that is only licensed under Apache License 2.0, pass `-DAPACHE_ONLY=1`
 to `bootstrap`.   
 For more information about licensing, please read our [blog post][blog-post] about the subject.
 

--- a/getting-started/installation-apt-ubuntu.md
+++ b/getting-started/installation-apt-ubuntu.md
@@ -2,8 +2,6 @@
 
 This will install TimescaleDB via `apt` on Ubuntu distros.
 
-**Note: TimescaleDB requires PostgreSQL 9.6.3+, 10.2+, or 11.0+**
-
 #### Prerequisites
 
 - Ubuntu 14.04 or later, except obsoleted versions.
@@ -62,10 +60,10 @@ a `postgres` superuser (used in the rest of the docs):
 sudo service postgresql restart
 ```
 
->:TIP: Our standard binary releases are licensed under the Timescale License. This means that you can use all of our free Community capabilities and seamlessly 
+>:TIP: Our standard binary releases are licensed under the Timescale License. This means that you can use all of our free Community capabilities and seamlessly
 activate Enterprise capabilities.  
-To build a version of this software that contains 
-source code that is only licensed under Apache License 2.0, pass `-DAPACHE_ONLY=1` 
+To build a version of this software that contains
+source code that is only licensed under Apache License 2.0, pass `-DAPACHE_ONLY=1`
 to `bootstrap`.   
 For more information about licensing, please read our [blog post][blog-post] about the subject.
 

--- a/getting-started/installation-homebrew.md
+++ b/getting-started/installation-homebrew.md
@@ -2,8 +2,6 @@
 
 This will install both TimescaleDB *and* PostgreSQL via Homebrew.
 
-**Note: TimescaleDB requires PostgreSQL 9.6.3+, 10.2+, or 11.0+**
-
 #### Prerequisites
 
 - [Homebrew][]
@@ -60,10 +58,10 @@ brew services restart postgresql
 createuser postgres -s
 ```
 
->:TIP: Our standard binary releases are licensed under the Timescale License. This means that you can use all of our free Community capabilities and seamlessly 
+>:TIP: Our standard binary releases are licensed under the Timescale License. This means that you can use all of our free Community capabilities and seamlessly
 activate Enterprise capabilities.  
-To build a version of this software that contains 
-source code that is only licensed under Apache License 2.0, pass `-DAPACHE_ONLY=1` 
+To build a version of this software that contains
+source code that is only licensed under Apache License 2.0, pass `-DAPACHE_ONLY=1`
 to `bootstrap`.   
 For more information about licensing, please read our [blog post][blog-post] about the subject.
 

--- a/getting-started/installation-source-windows.md
+++ b/getting-started/installation-source-windows.md
@@ -1,7 +1,5 @@
 ## From Source (Windows) [](installation-source)
 
-**Note: TimescaleDB requires PostgreSQL 9.6.3+, 10.2+, or 11.0+**
-
 #### Prerequisites
 
 - A standard **PostgreSQL 9.6, 10, or 11 64-bit** installation
@@ -60,10 +58,10 @@ shared_preload_libraries = 'timescaledb'
 
 Then, restart the PostgreSQL instance.
 
->:TIP: Our standard binary releases are licensed under the Timescale License. This means that you can use all of our free Community capabilities and seamlessly 
+>:TIP: Our standard binary releases are licensed under the Timescale License. This means that you can use all of our free Community capabilities and seamlessly
 activate Enterprise capabilities.  
-To build a version of this software that contains 
-source code that is only licensed under Apache License 2.0, pass `-DAPACHE_ONLY=1` 
+To build a version of this software that contains
+source code that is only licensed under Apache License 2.0, pass `-DAPACHE_ONLY=1`
 to `bootstrap`.   
 For more information about licensing, please read our [blog post][blog-post] about the subject.
 

--- a/getting-started/installation-source.md
+++ b/getting-started/installation-source.md
@@ -1,7 +1,5 @@
 ## From Source [](installation-source)
 
-**Note: TimescaleDB requires PostgreSQL 9.6.3+, 10.2+, or 11.0+**
-
 #### Prerequisites
 
 - A standard **PostgreSQL 9.6, 10, or 11** installation with development environment (header files) (see https://www.postgresql.org/download/ for the appropriate package)
@@ -53,10 +51,10 @@ shared_preload_libraries = 'timescaledb'
 
 Then, restart the PostgreSQL instance.
 
->:TIP: Our standard binary releases are licensed under the Timescale License. This means that you can use all of our free Community capabilities and seamlessly 
+>:TIP: Our standard binary releases are licensed under the Timescale License. This means that you can use all of our free Community capabilities and seamlessly
 activate Enterprise capabilities.  
-To build a version of this software that contains 
-source code that is only licensed under Apache License 2.0, pass `-DAPACHE_ONLY=1` 
+To build a version of this software that contains
+source code that is only licensed under Apache License 2.0, pass `-DAPACHE_ONLY=1`
 to `bootstrap`.   
 For more information about licensing, please read our [blog post][blog-post] about the subject.
 

--- a/getting-started/installation-windows.md
+++ b/getting-started/installation-windows.md
@@ -1,7 +1,5 @@
 ## Windows ZIP Installer [](installation-windows)
 
-**Note: TimescaleDB requires PostgreSQL 9.6.3+,  10.2+, or 11.0+**
-
 #### Prerequisites
 
 - [Visual C++ Redistributable for Visual Studio 2015][c_plus] (included in VS 2015 and later)
@@ -45,10 +43,10 @@ shared_preload_libraries = 'timescaledb'
 
 Then, restart the PostgreSQL instance.
 
->:TIP: Our standard binary releases are licensed under the Timescale License. This means that you can use all of our free Community capabilities and seamlessly 
+>:TIP: Our standard binary releases are licensed under the Timescale License. This means that you can use all of our free Community capabilities and seamlessly
 activate Enterprise capabilities.  
-To build a version of this software that contains 
-source code that is only licensed under Apache License 2.0, pass `-DAPACHE_ONLY=1` 
+To build a version of this software that contains
+source code that is only licensed under Apache License 2.0, pass `-DAPACHE_ONLY=1`
 to `bootstrap`.   
 For more information about licensing, please read our [blog post][blog-post] about the subject.
 

--- a/getting-started/installation-yum.md
+++ b/getting-started/installation-yum.md
@@ -3,8 +3,6 @@
 This will install both TimescaleDB *and* PostgreSQL via `yum`
 (or `dnf` on Fedora).
 
-**Note: TimescaleDB requires PostgreSQL 9.6.3+, 10.2+, or 11.0+**
-
 #### Prerequisites
 
 - RHEL/CentOS 7 (or Fedora equivalent) or later
@@ -72,10 +70,10 @@ a `postgres` superuser (used in the rest of the docs). Please
 refer to your distribution for how to restart services and
 [these instructions for adding a `postgres` user][createuser].
 
->:TIP: Our standard binary releases are licensed under the Timescale License. This means that you can use all of our free Community capabilities and seamlessly 
+>:TIP: Our standard binary releases are licensed under the Timescale License. This means that you can use all of our free Community capabilities and seamlessly
 activate Enterprise capabilities.  
-To build a version of this software that contains 
-source code that is only licensed under Apache License 2.0, pass `-DAPACHE_ONLY=1` 
+To build a version of this software that contains
+source code that is only licensed under Apache License 2.0, pass `-DAPACHE_ONLY=1`
 to `bootstrap`.   
 For more information about licensing, please read our [blog post][blog-post] about the subject.
 


### PR DESCRIPTION
Now that we have a postgres version picker, this removes the note about which versions of postgres to use, since it's repetitive with the version picker.