### PR TITLE
Add tip for installing Apache binaries

### DIFF
--- a/getting-started/installation-apt-debian.md
+++ b/getting-started/installation-apt-debian.md
@@ -61,12 +61,13 @@ a `postgres` superuser (used in the rest of the docs):
 sudo service postgresql restart
 ```
 
->:TIP: Our standard binary releases are licensed under the Timescale License. This means that you can use all of our free Community capabilities and seamlessly 
-activate Enterprise capabilities.  
-To build a version of this software that contains 
-source code that is only licensed under Apache License 2.0, pass `-DAPACHE_ONLY=1` 
-to `bootstrap`.   
-For more information about licensing, please read our [blog post][blog-post] about the subject.
+>:TIP: Our standard binary releases are licensed under the Timescale License.
+This means that you can use all of our free Community capabilities and
+seamlessly activate Enterprise capabilities.
+If you want to use a version that contains _only_ Apache 2.0 licensed
+code, you should install the package `timescaledb-oss-postgresql-:pg_version:`.
+For more information about licensing, please read our [blog post][blog-post]
+about the subject.
 
 [Here are some instructions to create the `postgres` superuser][createuser].
 

--- a/getting-started/installation-apt-ubuntu.md
+++ b/getting-started/installation-apt-ubuntu.md
@@ -62,12 +62,13 @@ a `postgres` superuser (used in the rest of the docs):
 sudo service postgresql restart
 ```
 
->:TIP: Our standard binary releases are licensed under the Timescale License. This means that you can use all of our free Community capabilities and seamlessly 
-activate Enterprise capabilities.  
-To build a version of this software that contains 
-source code that is only licensed under Apache License 2.0, pass `-DAPACHE_ONLY=1` 
-to `bootstrap`.   
-For more information about licensing, please read our [blog post][blog-post] about the subject.
+>:TIP: Our standard binary releases are licensed under the Timescale License.
+This means that you can use all of our free Community capabilities and
+seamlessly activate Enterprise capabilities.
+If you want to use a version that contains _only_ Apache 2.0 licensed
+code, you should install the package `timescaledb-oss-postgresql-:pg_version:`.
+For more information about licensing, please read our [blog post][blog-post]
+about the subject.
 
 [Here are some instructions to create the `postgres` superuser][createuser].
 

--- a/getting-started/installation-docker.md
+++ b/getting-started/installation-docker.md
@@ -68,12 +68,13 @@ until explicitly removed. Use `docker volume ls` to list the existing
 docker volumes.
 ([More information on data volumes][docker-data-volumes])
 
->:TIP: Our standard binary releases are licensed under the Timescale License. This means that you can use all of our free Community capabilities and seamlessly 
-activate Enterprise capabilities.  
-To build a version of this software that contains 
-source code that is only licensed under Apache License 2.0, pass `-DAPACHE_ONLY=1` 
-to `bootstrap`.   
-For more information about licensing, please read our [blog post][blog-post] about the subject.
+>:TIP: Our standard binary releases are licensed under the Timescale License.
+This means that you can use all of our free Community capabilities and
+seamlessly activate Enterprise capabilities.
+If you want to use a version that contains _only_ Apache 2.0 licensed
+code, you should pull the tag `latest-pg:pg_version:-oss`.
+For more information about licensing, please read our [blog post][blog-post]
+about the subject.
 
 ## Prebuilt with PostGIS [](postgis-docker)
 

--- a/getting-started/installation-homebrew.md
+++ b/getting-started/installation-homebrew.md
@@ -60,12 +60,13 @@ brew services restart postgresql
 createuser postgres -s
 ```
 
->:TIP: Our standard binary releases are licensed under the Timescale License. This means that you can use all of our free Community capabilities and seamlessly 
-activate Enterprise capabilities.  
-To build a version of this software that contains 
-source code that is only licensed under Apache License 2.0, pass `-DAPACHE_ONLY=1` 
-to `bootstrap`.   
-For more information about licensing, please read our [blog post][blog-post] about the subject.
+>:TIP: Our standard binary releases are licensed under the Timescale License.
+This means that you can use all of our free Community capabilities and
+seamlessly activate Enterprise capabilities.
+If you want to use a version that contains _only_ Apache 2.0 licensed
+code, you should use `brew install timescaledb --with-oss-only`.
+For more information about licensing, please read our [blog post][blog-post]
+about the subject.
 
 [Homebrew]: https://brew.sh/
 [blog-post]: https://blog.timescale.com/how-we-are-building-an-open-source-business-a7701516a480

--- a/getting-started/installation-yum.md
+++ b/getting-started/installation-yum.md
@@ -72,12 +72,13 @@ a `postgres` superuser (used in the rest of the docs). Please
 refer to your distribution for how to restart services and
 [these instructions for adding a `postgres` user][createuser].
 
->:TIP: Our standard binary releases are licensed under the Timescale License. This means that you can use all of our free Community capabilities and seamlessly 
-activate Enterprise capabilities.  
-To build a version of this software that contains 
-source code that is only licensed under Apache License 2.0, pass `-DAPACHE_ONLY=1` 
-to `bootstrap`.   
-For more information about licensing, please read our [blog post][blog-post] about the subject.
+>:TIP: Our standard binary releases are licensed under the Timescale License.
+This means that you can use all of our free Community capabilities and
+seamlessly activate Enterprise capabilities.
+If you want to use a version that contains _only_ Apache 2.0 licensed
+code, you should install the package `timescaledb-oss-postgresql-:pg_version:`.
+For more information about licensing, please read our [blog post][blog-post]
+about the subject.
 
 [createuser]: http://suite.opengeo.org/docs/latest/dataadmin/pgGettingStarted/firstconnect.html
 [pgdg]: https://yum.postgresql.org/repopackages.php


### PR DESCRIPTION
Some users may want to continue using only Apache 2.0 bits, so we
should include tips on how to install those versions for the
channels that support it (Homebrew, Docker, Linux).