### PR TITLE
Add timescaledb-tune to install pages

### DIFF
--- a/getting-started/installation-apt-debian.md
+++ b/getting-started/installation-apt-debian.md
@@ -37,22 +37,20 @@ sudo apt-get update
 sudo apt-get install timescaledb-postgresql-:pg_version:
 ```
 
-#### Update `postgresql.conf`
+#### Configure your database
 
->:TIP: The usual location of `postgres.conf`
-is `/etc/postgresql/:pg_version:/main/postgresql.conf`, but this may vary
-depending on your setup. If you are unsure where your `postgresql.conf` file
-is located, you can query PostgreSQL with any database client (e.g., `psql`)
-using `SHOW config_file;`.
-
-You will need to edit your `postgresql.conf` file to include
-necessary libraries:
+There are a [variety of settings that can be configured][config] for your
+new database. At a minimum, you will need to update your `postgresql.conf` file
+to include our library to the parameter `shared_preload_libraries`.
+The easiest way to get started is to run `timescaledb-tune`, which is
+installed by default when using `apt`:
 ```bash
-# Modify postgresql.conf to uncomment this line and add required libraries.
-shared_preload_libraries = 'timescaledb'
+sudo timescaledb-tune
 ```
 
->:TIP: If you have other libraries you are preloading, they should be comma separated.
+This will ensure that our extension is properly added to the parameter
+`shared_preload_libraries` as well as offer suggestions for tuning memory,
+parallelism, and other settings.
 
 To get started you'll now need to restart PostgreSQL and add
 a `postgres` superuser (used in the rest of the docs):
@@ -60,6 +58,8 @@ a `postgres` superuser (used in the rest of the docs):
 # Restart PostgreSQL instance
 sudo service postgresql restart
 ```
+
+Here are [some instructions to create the `postgres` superuser][createuser].
 
 >:TIP: Our standard binary releases are licensed under the Timescale License.
 This means that you can use all of our free Community capabilities and
@@ -69,7 +69,6 @@ code, you should install the package `timescaledb-oss-postgresql-:pg_version:`.
 For more information about licensing, please read our [blog post][blog-post]
 about the subject.
 
-[Here are some instructions to create the `postgres` superuser][createuser].
-
+[config]: /getting-started/configuring
 [createuser]: http://suite.opengeo.org/docs/latest/dataadmin/pgGettingStarted/firstconnect.html
 [blog-post]: https://blog.timescale.com/how-we-are-building-an-open-source-business-a7701516a480

--- a/getting-started/installation-apt-ubuntu.md
+++ b/getting-started/installation-apt-ubuntu.md
@@ -38,22 +38,20 @@ sudo apt-get update
 sudo apt install timescaledb-postgresql-:pg_version:
 ```
 
-#### Update `postgresql.conf`
+#### Configure your database
 
->:TIP: The usual location of `postgres.conf`
-is `/etc/postgresql/:pg_version:/main/postgresql.conf`, but this may vary
-depending on your setup. If you are unsure where your `postgresql.conf` file
-is located, you can query PostgreSQL with any database client (e.g., `psql`)
-using `SHOW config_file;`.
-
-You will need to edit your `postgresql.conf` file to include
-necessary libraries:
+There are a [variety of settings that can be configured][config] for your
+new database. At a minimum, you will need to update your `postgresql.conf` file
+to include our library to the parameter `shared_preload_libraries`.
+The easiest way to get started is to run `timescaledb-tune`, which is
+installed by default when using `apt`:
 ```bash
-# Modify postgresql.conf to uncomment this line and add required libraries.
-shared_preload_libraries = 'timescaledb'
+sudo timescaledb-tune
 ```
 
->:TIP: If you have other libraries you are preloading, they should be comma separated.
+This will ensure that our extension is properly added to the parameter
+`shared_preload_libraries` as well as offer suggestions for tuning memory,
+parallelism, and other settings.
 
 To get started you'll now need to restart PostgreSQL and add
 a `postgres` superuser (used in the rest of the docs):
@@ -72,6 +70,7 @@ about the subject.
 
 [Here are some instructions to create the `postgres` superuser][createuser].
 
+[config]: /getting-started/configuring
 [createuser]: http://suite.opengeo.org/docs/latest/dataadmin/pgGettingStarted/firstconnect.html
 [ubuntu-releases]: http://releases.ubuntu.com/
 [blog-post]: https://blog.timescale.com/how-we-are-building-an-open-source-business-a7701516a480

--- a/getting-started/installation-homebrew.md
+++ b/getting-started/installation-homebrew.md
@@ -27,24 +27,20 @@ brew install timescaledb
 /usr/local/bin/timescaledb_move.sh
 ```
 
-#### Update `postgresql.conf`
+#### Configure your database
 
->:TIP: The usual location of `postgresql.conf` is
-`/usr/local/var/postgres/postgresql.conf`, but this may vary depending on
-your setup. If you are unsure where your `postgresql.conf` file
-is located, you can query PostgreSQL with any database client (e.g., `psql`)
-using `SHOW config_file;`.
-
-Also, you will need to edit your `postgresql.conf` file to include
-necessary libraries:
-
+There are a [variety of settings that can be configured][config] for your
+new database. At a minimum, you will need to update your `postgresql.conf` file
+to include our library to the parameter `shared_preload_libraries`.
+The easiest way to get started is to run `timescaledb-tune`, which is
+installed as a dependency when you install via Homebrew:
 ```bash
-# Modify postgresql.conf to uncomment this line and add required libraries.
-# For example:
-shared_preload_libraries = 'timescaledb'
+timescaledb-tune
 ```
 
->:TIP: If you have other libraries you are preloading, they should be comma separated.
+This will ensure that our extension is properly added to the parameter
+`shared_preload_libraries` as well as offer suggestions for tuning memory,
+parallelism, and other settings.
 
 To get started you'll now need to restart PostgreSQL and add
 a `postgres` superuser (used in the rest of the docs):
@@ -68,5 +64,6 @@ code, you should use `brew install timescaledb --with-oss-only`.
 For more information about licensing, please read our [blog post][blog-post]
 about the subject.
 
+[config]: /getting-started/configuring
 [Homebrew]: https://brew.sh/
 [blog-post]: https://blog.timescale.com/how-we-are-building-an-open-source-business-a7701516a480

--- a/getting-started/installation-yum.md
+++ b/getting-started/installation-yum.md
@@ -50,22 +50,20 @@ sudo yum update -y
 sudo yum install -y timescaledb-postgresql-:pg_version:
 ```
 
-#### Update `postgresql.conf`
+#### Configure your database
 
->:TIP: The usual location of `postgres.conf` is
-`/var/lib/pgsql/:pg_version:/data/postgresql.conf`, but this may vary depending
-on your setup. If you are unsure where your `postgresql.conf` file
-is located, you can query PostgreSQL with any database client (e.g., `psql`)
-using `SHOW config_file;`.
-
-You will need to edit your `postgresql.conf` file to include
-necessary libraries:
+There are a [variety of settings that can be configured][config] for your
+new database. At a minimum, you will need to update your `postgresql.conf` file
+to include our library to the parameter `shared_preload_libraries`.
+The easiest way to get started is to run `timescaledb-tune`, which is
+installed by default when using `yum`:
 ```bash
-# Modify postgresql.conf to uncomment this line and add required libraries.
-shared_preload_libraries = 'timescaledb'
+sudo timescaledb-tune
 ```
 
->:TIP: If you have other libraries you are preloading, they should be comma separated.
+This will ensure that our extension is properly added to the parameter
+`shared_preload_libraries` as well as offer suggestions for tuning memory,
+parallelism, and other settings.
 
 To get started you'll need to restart PostgreSQL and add
 a `postgres` superuser (used in the rest of the docs). Please
@@ -80,6 +78,7 @@ code, you should install the package `timescaledb-oss-postgresql-:pg_version:`.
 For more information about licensing, please read our [blog post][blog-post]
 about the subject.
 
+[config]: /getting-started/configuring
 [createuser]: http://suite.opengeo.org/docs/latest/dataadmin/pgGettingStarted/firstconnect.html
 [pgdg]: https://yum.postgresql.org/repopackages.php
 [yuminstall]: https://wiki.postgresql.org/wiki/YUM_Installation


### PR DESCRIPTION
Now that our binary packages typically include timescaledb-tune,
we can remove the manual editting of postgresql.conf and replace it
with a call to timescaledb-tune. For new users, this is probably
easier and less error prone.