### PR TITLE
Change `Deleting a Hypertable` anchor to #drop

### DIFF
--- a/using-timescaledb/hypertables.md
+++ b/using-timescaledb/hypertables.md
@@ -59,7 +59,7 @@ the chunks that constitute this hypertable.
 
 ---
 
-### Deleting a Hypertable [](delete)
+### Deleting a Hypertable [](drop)
 
 It's just the standard `DROP TABLE` command, where TimescaleDB will
 correspondingly delete all chunks belonging to the hypertable.


### PR DESCRIPTION
Fixes the submenu which is pointing to `https://docs.timescale.com/v0.12/using-timescaledb/hypertables#drop` instead of #delete.