### PR TITLE
Fix GitHub spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The admin for the docs will use that as a guide when updating version branches.
 
 ### A note on page links
 
-None of the internal page links within these files will work on Github.  They are designed to function within the code for the documentation site at [docs.timescale.com](http://docs.timescale.com).  All external links should work.
+None of the internal page links within these files will work on GitHub.  They are designed to function within the code for the documentation site at [docs.timescale.com](http://docs.timescale.com).  All external links should work.
 
 ### A note on anchors
 

--- a/faq.md
+++ b/faq.md
@@ -323,7 +323,7 @@ See our [updating documentation][update]. [[Top]](#top)
 [last]: /api#last
 [data-retention]: http://docs.timescale.com/using-timescaledb/data-retention
 [postgis]: /tutorials/tutorial-hello-nyc#tutorial-postgis
-[Github]: https://github.com/timescale/timescaledb/issues
+[GitHub]: https://github.com/timescale/timescaledb/issues
 [joining our Slack group]: https://slack-login.timescale.com/
 [install]: /getting-started/installation
 [update]: /using-timescaledb/update-db

--- a/getting-started/installation-source-windows.md
+++ b/getting-started/installation-source-windows.md
@@ -13,7 +13,7 @@
 >:TIP: It is **highly recommended** that you checkout the latest
 tagged commit to build from (see the repo's [Releases][github-releases] page for that)
 
-Clone the repository from [Github][github-timescale]:
+Clone the repository from [GitHub][github-timescale]:
 
 ```bash
 git clone https://github.com/timescale/timescaledb.git

--- a/getting-started/installation-source.md
+++ b/getting-started/installation-source.md
@@ -12,7 +12,7 @@
 >:TIP: It is **highly recommended** that you checkout the latest
 tagged commit to build from (see the repo's [Releases][github-releases] page for that)
 
-Clone the repository from [Github][github-timescale]:
+Clone the repository from [GitHub][github-timescale]:
 ```bash
 git clone https://github.com/timescale/timescaledb.git
 cd timescaledb

--- a/getting-started/migrating-data.md
+++ b/getting-started/migrating-data.md
@@ -202,7 +202,7 @@ timescaledb-parallel-copy --db-name new_db --table conditions \
 ```
 
 In addition to parallelizing the workload, the tool also offers flags
-to improve the copy experience. [See the repo on Github][parallel importer] for full details.
+to improve the copy experience. [See the repo on GitHub][parallel importer] for full details.
 
 >:TIP: We recommend not setting the number of workers higher than
 the number of available CPU cores on the machine.


### PR DESCRIPTION
Github -> GitHub

There are also three typos on the main https://www.timescale.com/ frontpage. If does not look like the website is hosted as a Git repo in the `timescale` org. It would be nice if you could fix those too. :)