### PR TITLE
yum: use the latest rpm for pgdg

### DIFF
--- a/getting-started/installation-yum.md
+++ b/getting-started/installation-yum.md
@@ -20,8 +20,8 @@ sure to remove non-`yum` installations before using this method.
 You'll need to [download the correct PGDG from PostgreSQL][pgdg] for
 your operating system and architecture and install it:
 ```bash
-# Download PGDG for PostgreSQL 11, e.g. for CentOS 7:
-sudo yum install -y https://download.postgresql.org/pub/repos/yum/11/redhat/rhel-7-x86_64/pgdg-centos11-11-2.noarch.rpm
+# Download PGDG for PostgreSQL 11, e.g. for RHEL 7:
+sudo yum install -y https://download.postgresql.org/pub/repos/yum/11/redhat/rhel-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm
 
 ## Follow the initial setup instructions found below:
 ```


### PR DESCRIPTION
There have been some recent changes to the PGDG packaging and the URL needs an update

https://yum.postgresql.org/repopackages.php now points to a "latest" package and suggests that all Red Hat 7 variants use the same rpm.

See also https://www.postgresql.org/message-id/flat/6f1e601300d575195d4f0d8a066ef4abf4c90c99.camel%40gunduz.org