### PR TITLE
Add new fields to telemetry example

### DIFF
--- a/using-timescaledb/telemetry.md
+++ b/using-timescaledb/telemetry.md
@@ -26,6 +26,9 @@ the JSON that is sent to our servers about a specific deployment:
 	"build_os_version": "4.9.125-linuxkit",
 	"data_volume": "65982148",
 	"num_hypertables": "3",
+	"num_continuous_aggs": "0",
+	"num_reorder_policies": "1",
+	"num_drop_chunks_policies": "2",
 	"related_extensions":
     	{
 		"pg_prometheus": "false",


### PR DESCRIPTION
Adds the following newly-added fields to the telemetry example:
- num_continuous_aggs
- num_reorder_policies
- num_drop_chunks_policies