### PR TITLE
Update Windows instructions and other small nits

### DIFF
--- a/getting-started/installation-apt-debian.md
+++ b/getting-started/installation-apt-debian.md
@@ -40,8 +40,8 @@ sudo apt-get install timescaledb-postgresql-:pg_version:
 #### Configure your database
 
 There are a [variety of settings that can be configured][config] for your
-new database. At a minimum, you will need to update your `postgresql.conf` file
-to include our library to the parameter `shared_preload_libraries`.
+new database. At a minimum, you will need to update your `postgresql.conf`
+file to include our library in the parameter `shared_preload_libraries`.
 The easiest way to get started is to run `timescaledb-tune`, which is
 installed by default when using `apt`:
 ```bash

--- a/getting-started/installation-apt-ubuntu.md
+++ b/getting-started/installation-apt-ubuntu.md
@@ -6,7 +6,7 @@ This will install TimescaleDB via `apt` on Ubuntu distros.
 
 #### Prerequisites
 
-- Ubuntu 14.04 or later, except obsoleted versions.
+- Ubuntu 16.04 or later, except obsoleted versions.
 Check [releases.ubuntu.com][ubuntu-releases] for list of
 non-obsolete releases.
 
@@ -41,8 +41,8 @@ sudo apt install timescaledb-postgresql-:pg_version:
 #### Configure your database
 
 There are a [variety of settings that can be configured][config] for your
-new database. At a minimum, you will need to update your `postgresql.conf` file
-to include our library to the parameter `shared_preload_libraries`.
+new database. At a minimum, you will need to update your `postgresql.conf`
+file to include our library in the parameter `shared_preload_libraries`.
 The easiest way to get started is to run `timescaledb-tune`, which is
 installed by default when using `apt`:
 ```bash

--- a/getting-started/installation-homebrew.md
+++ b/getting-started/installation-homebrew.md
@@ -30,8 +30,8 @@ brew install timescaledb
 #### Configure your database
 
 There are a [variety of settings that can be configured][config] for your
-new database. At a minimum, you will need to update your `postgresql.conf` file
-to include our library to the parameter `shared_preload_libraries`.
+new database. At a minimum, you will need to update your `postgresql.conf`
+file to include our library in the parameter `shared_preload_libraries`.
 The easiest way to get started is to run `timescaledb-tune`, which is
 installed as a dependency when you install via Homebrew:
 ```bash

--- a/getting-started/installation-source-windows.md
+++ b/getting-started/installation-source-windows.md
@@ -4,7 +4,7 @@
 
 #### Prerequisites
 
-- A standard **PostgreSQL 9.6, 10, or 11 64-bit** installation
+- A standard **PostgreSQL :pg_version: 64-bit** installation
 - Visual Studio 2017 (with [CMake][] and Git components)  
   **or** Visual Studio 2015/2016 (with [CMake][] version 3.4+ and Git components)
 - Make sure all relevant binaries are in your PATH: `pg_config` and `cmake`
@@ -45,14 +45,15 @@ cmake --build ./build --config Release --target install
 
 #### Update `postgresql.conf`
 
-Also, you will need to edit your `postgresql.conf` file to include
-necessary libraries, and then restart PostgreSQL. First, locate your postgresql.conf file:
+You will need to edit your `postgresql.conf` file to include
+the TimescaleDB library, and then restart PostgreSQL. First, locate your
+`postgresql.conf` file:
 
 ```bash
 psql -d postgres -c "SHOW config_file;"
 ```
 
-Then modify `postgresql.conf` to add required libraries.  Note that
+Then modify `postgresql.conf` to add the required library.  Note that
 the `shared_preload_libraries` line is commented out by default.
 Make sure to uncomment it when adding our library.
 
@@ -63,10 +64,10 @@ shared_preload_libraries = 'timescaledb'
 
 Then, restart the PostgreSQL instance.
 
->:TIP: Our standard binary releases are licensed under the Timescale License. This means that you can use all of our free Community capabilities and seamlessly 
+>:TIP: Our standard binary releases are licensed under the Timescale License. This means that you can use all of our free Community capabilities and seamlessly
 activate Enterprise capabilities.  
-To build a version of this software that contains 
-source code that is only licensed under Apache License 2.0, pass `-DAPACHE_ONLY=1` 
+To build a version of this software that contains
+source code that is only licensed under Apache License 2.0, pass `-DAPACHE_ONLY=1`
 to `bootstrap`.   
 For more information about licensing, please read our [blog post][blog-post] about the subject.
 

--- a/getting-started/installation-source.md
+++ b/getting-started/installation-source.md
@@ -4,7 +4,7 @@
 
 #### Prerequisites
 
-- A standard **PostgreSQL 9.6, 10, or 11** installation with development environment (header files) (see https://www.postgresql.org/download/ for the appropriate package)
+- A standard **PostgreSQL :pg_version:** installation with development environment (header files) (see https://www.postgresql.org/download/ for the appropriate package)
 - C compiler (e.g., gcc or clang)
 - [CMake][] version 3.4 or greater
 
@@ -36,13 +36,14 @@ installed with.
 #### Update `postgresql.conf`
 
 You will need to edit your `postgresql.conf` file to include
-necessary libraries, and then restart PostgreSQL. First, locate your postgresql.conf file:
+the TimescaleDB library, and then restart PostgreSQL. First, locate your
+`postgresql.conf` file:
 
 ```bash
 psql -d postgres -c "SHOW config_file;"
 ```
 
-Then modify `postgresql.conf` to add required libraries.  Note that
+Then modify `postgresql.conf` to add the required library.  Note that
 the `shared_preload_libraries` line is commented out by default.
 Make sure to uncomment it when adding our library.
 
@@ -53,10 +54,10 @@ shared_preload_libraries = 'timescaledb'
 
 Then, restart the PostgreSQL instance.
 
->:TIP: Our standard binary releases are licensed under the Timescale License. This means that you can use all of our free Community capabilities and seamlessly 
+>:TIP: Our standard binary releases are licensed under the Timescale License. This means that you can use all of our free Community capabilities and seamlessly
 activate Enterprise capabilities.  
-To build a version of this software that contains 
-source code that is only licensed under Apache License 2.0, pass `-DAPACHE_ONLY=1` 
+To build a version of this software that contains
+source code that is only licensed under Apache License 2.0, pass `-DAPACHE_ONLY=1`
 to `bootstrap`.   
 For more information about licensing, please read our [blog post][blog-post] about the subject.
 

--- a/getting-started/installation-windows.md
+++ b/getting-started/installation-windows.md
@@ -5,7 +5,7 @@
 #### Prerequisites
 
 - [Visual C++ Redistributable for Visual Studio 2015][c_plus] (included in VS 2015 and later)
-- A standard **PostgreSQL (9.6, 10, or 11) 64-bit** installation
+- A standard **PostgreSQL :pg_version: 64-bit** installation
 - Make sure all relevant binaries are in your PATH: (use [pg_config][])
 
 #### Build & Install
@@ -23,32 +23,24 @@ Press ENTER/Return key to close...
 ```
 Go ahead and press ENTER to close the window
 
+#### Configure your database
 
-#### Update `postgresql.conf`
+There are a [variety of settings that can be configured][config] for your
+new database. At a minimum, you will need to update your `postgresql.conf`
+file to include our library in the parameter `shared_preload_libraries`.
+If you ran `timescaledb-tune` during the install, you are already done.
+If you did not, you can re-run the installer.
 
-You will need to edit your `postgresql.conf` file to include necessary
-libraries, and then restart PostgreSQL. First, locate your `postgresql.conf`
-file:
-
-```bash
-psql -d postgres -c "SHOW config_file;"
-```
-
-Then modify `postgresql.conf` to add required libraries.  Note that
-the `shared_preload_libraries` line is commented out by default.
-Make sure to uncomment it when adding our library.
-
-```bash
-shared_preload_libraries = 'timescaledb'
-```
->:TIP: If you have other libraries you are preloading, they should be comma separated.
+This will ensure that our extension is properly added to the parameter
+`shared_preload_libraries` as well as offer suggestions for tuning memory,
+parallelism, and other settings.
 
 Then, restart the PostgreSQL instance.
 
->:TIP: Our standard binary releases are licensed under the Timescale License. This means that you can use all of our free Community capabilities and seamlessly 
+>:TIP: Our standard binary releases are licensed under the Timescale License. This means that you can use all of our free Community capabilities and seamlessly
 activate Enterprise capabilities.  
-To build a version of this software that contains 
-source code that is only licensed under Apache License 2.0, pass `-DAPACHE_ONLY=1` 
+To build a version of this software that contains
+source code that is only licensed under Apache License 2.0, pass `-DAPACHE_ONLY=1`
 to `bootstrap`.   
 For more information about licensing, please read our [blog post][blog-post] about the subject.
 

--- a/getting-started/installation-yum.md
+++ b/getting-started/installation-yum.md
@@ -53,8 +53,8 @@ sudo yum install -y timescaledb-postgresql-:pg_version:
 #### Configure your database
 
 There are a [variety of settings that can be configured][config] for your
-new database. At a minimum, you will need to update your `postgresql.conf` file
-to include our library to the parameter `shared_preload_libraries`.
+new database. At a minimum, you will need to update your `postgresql.conf`
+file to include our library in the parameter `shared_preload_libraries`.
 The easiest way to get started is to run `timescaledb-tune`, which is
 installed by default when using `yum`:
 ```bash


### PR DESCRIPTION
Using the Windows installer usually obviates the need for manually
updating postgresql.conf since timescaledb-tune is run. Given that,
we update the instruction page to better reflect this.

Also, minor grammar mistakes are fixed and simplify the prerequisites
in light of the :pg_version: macro.