### PR TITLE
Update get_telemetry_report

### DIFF
--- a/api.md
+++ b/api.md
@@ -2168,12 +2168,24 @@ Where `chunk_table` is the table that contains the data, `table_size` is the siz
 
 ## get_telemetry_report() [](get_telemetry_report)
 
-This function returns the text string that is sent to our servers if
-background [telemetry][] is enabled. It takes no arguments.
+If background [telemetry][] is enabled, returns the string sent to our servers. 
+If telemetry is not enabled, outputs INFO message affirming telemetry is disabled
+and returns a NULL report. 
+
+#### Optional Arguments [](get_telemetry_report-optional-arguments)
+
+|Name|Description|
+|---|---|
+| `always_display_report` | Set to true to always view the report, even if telemetry is disabled |
 
 #### Sample Usage [](get_telemetry_report-examples)
+If telemetry is enabled, view the telemetry report.
 ```sql
-SELECT get_telemetry_report()
+SELECT get_telemetry_report();
+```
+If telemetry is disabled, view the telemetry report locally.
+```sql
+SELECT get_telemetry_report(always_display_report := true);
 ```
 
 ---


### PR DESCRIPTION
An optional argument was added to the get_telemetry_report() function to
allow users to get the telemetry report even if they have disabled telemetry.