### PR TITLE
Change Intro title

### DIFF
--- a/page-index/page-index.js
+++ b/page-index/page-index.js
@@ -12,7 +12,7 @@ import {
 
 const pageIndex = [
     {
-        Title: "Understanding TimescaleDB",
+        Title: "Overview",
         type: PAGE,
         href: "introduction",
         children: [
@@ -375,7 +375,7 @@ const pageIndex = [
                 Title: "Tooling",
                 type: PAGE,
                 href: "tooling"
-            }, {   
+            }, {
                 Title: "Update software",
                 type: PAGE,
                 href: "update-db"


### PR DESCRIPTION
The title for the intro section "Understanding TimescaleDB" is too long
which results in a strange effect where when the subsection is open,
the title is split along two lines.  This change should prevent that
from happening.