### PR TITLE
Add CASCADE option to delete_data_node and warning

### DIFF
--- a/getting-started/scaling-out.md
+++ b/getting-started/scaling-out.md
@@ -86,7 +86,7 @@ foreign data wrapper and any data node (server) objects.
 Deleting a data node is done by calling `delete_data_node`:
 
 ```sql
-SELECT delete_data_node('node1', cascade=>'true');
+SELECT delete_data_node('node1', cascade=>true);
 ```
 >:TIP: Note that a data node cannot be deleted if it contains data for a
 hypertable, since otherwise data would be lost.

--- a/getting-started/scaling-out.md
+++ b/getting-started/scaling-out.md
@@ -86,11 +86,14 @@ foreign data wrapper and any data node (server) objects.
 Deleting a data node is done by calling `delete_data_node`:
 
 ```sql
-SELECT delete_data_node('node1');
+SELECT delete_data_node('node1', cascade=>'true');
 ```
 >:TIP: Note that a data node cannot be deleted if it contains data for a
 hypertable, since otherwise data would be lost.
 
+>:WARNING: Although the `cascade` parameter is not strictly a required argument,
+you *MUST* set it to `true` to avoid breaking necessary user mappings.
+  
 ### Information Schema for Data Nodes
 
 The data nodes that have been added to the distributed database

--- a/getting-started/scaling-out.md
+++ b/getting-started/scaling-out.md
@@ -92,7 +92,8 @@ SELECT delete_data_node('node1', cascade=>'true');
 hypertable, since otherwise data would be lost.
 
 >:WARNING: Although the `cascade` parameter is not strictly a required argument,
-you *MUST* set it to `true` to avoid breaking necessary user mappings.
+you *MUST* set it to `true` in this current release to avoid putting TimescaleDB
+in a recoverable error state.
   
 ### Information Schema for Data Nodes
 


### PR DESCRIPTION
It is important to set CASCADE option to true, thus it is added in the example and warning is given. In sync with `delete_data_node` API doc.