### PR TITLE
Fix the nyc_data_contagg.sql filename in continuous-aggs-tutorial

### DIFF
--- a/tutorials/continuous-aggs-tutorial.md
+++ b/tutorials/continuous-aggs-tutorial.md
@@ -31,7 +31,7 @@ TimescaleDB installed (version 1.3 or greater)
 Let's start by downloading the data.
 
 This dataset contains two files:
-1. `contagg_nyc_data.sql` - A SQL file that will set up the necessary tables
+1. `nyc_data_contagg.sql` - A SQL file that will set up the necessary tables
 for the continuous aggregates tutorial.
 1. `nyc_data_rides.csv` - A CSV file with the ride data.
 
@@ -54,7 +54,7 @@ Then, follow these steps:
 tar -xvzf nyc_data.tar.gz
 
 # (2) import the table schemas
-psql -U postgres -d nyc_data -h localhost <  contagg_nyc_data.sql
+psql -U postgres -d nyc_data -h localhost <  nyc_data_contagg.sql
 
 # (3) import data
 psql -U postgres -d nyc_data -h localhost -c "\COPY rides FROM nyc_data_rides.csv CSV"


### PR DESCRIPTION
Fix the nyc_data_contagg.sql filename in continuous-aggs-tutorial

Moreover, in this file under nyc_data.tar.gz (hosted on https://timescaledata.blob.core.windows.net/datasets/nyc_data.tar.gz), these should be added on the top:

```
DROP EXTENSION IF EXISTS timescaledb;
CREATE EXTENSION IF NOT EXISTS timescaledb;
DROP TABLE IF EXISTS "rides";
```

If these are not in the file, it throws the following error:
```
ERROR:  function create_hypertable(unknown, unknown) does not exist
LINE 1: SELECT create_hypertable('rides', 'pickup_datetime');
               ^
HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
```