### PR TITLE
Update used Telegraf version

### DIFF
--- a/tutorials/telegraf-output-plugin.md
+++ b/tutorials/telegraf-output-plugin.md
@@ -18,7 +18,7 @@ Before we start, you will need [TimescaleDB installed][getting-started] and a me
 
 ### Setting up Telegraf
 
-Telegraf is written in Go, and the current build process of the tool is configured to produce one standalone binary. Because of this all the code for the different plugins must be part of that binary. We have an unofficial build of Telegraf version 1.10.4 with our plugin added. You can download from the following links: 
+Telegraf is written in Go, and the current build process of the tool is configured to produce one standalone binary. Because of this all the code for the different plugins must be part of that binary. We have an unofficial build of Telegraf version 1.11.3 with our plugin added. You can download from the following links: 
 
 * Linux amd64: [:DOWNLOAD_LINK: `deb`][deb-build] [:DOWNLOAD_LINK: `rpm`][rpm-build] [:DOWNLOAD_LINK: `binary`][linux-bin-build]
 * Windows amd64 [:DOWNLOAD_LINK: `binary/exe`][windows-build]
@@ -40,7 +40,7 @@ We can check the version of the installed Telegraf with
 $ telegraf --version
 ```
 
-If the installation was successful it should print out `Telegraf 1.10.4-with-pg`.
+If the installation was successful it should print out `Telegraf 1.11.3-with-pg`.
 
 ## Telegraf Configuration [](telegraf-configuration)
 
@@ -103,15 +103,17 @@ laid out.
   ##       ?sslmode=[disable|verify-ca|verify-full]
   ## or a simple string:
   ##   host=localhost user=pqotest password=... sslmode=... dbname=app_production
-  ##  
-  ## All connection parameters are optional.
-  ##  
+  ##
+  ## All connection parameters are optional. Also supported are PG environment vars
+  ## e.g. PGPASSWORD, PGHOST, PGUSER, PGDATABASE 
+  ## all supported vars here: https://www.postgresql.org/docs/current/libpq-envars.html
+  ##
   ## Without the dbname parameter, the driver will default to a database
   ## with the same name as the user. This dbname is just for instantiating a
   ## connection with the server and doesn't restrict the databases we are trying
   ## to grab metrics for.
-  ##  
-  address = "host=localhost user=postgres sslmode=verify-full"
+  ##
+  connection = "host=localhost user=postgres sslmode=verify-full"
 
   ## Store tags as foreign keys in the metrics table. Default is false.
   # tags_as_foreignkeys = false
@@ -138,13 +140,13 @@ laid out.
 
 From the config we can notice several things:
 1. The top line enables the plugin, the plugin specific config is indented after this line
-2. There is currently only one parameter configured, `address`. The others are commented out
+2. There is currently only one parameter configured, `connection`. The others are commented out
 3. Possible parameters are commented out with a single `#`. (`tags_as_foreignkeys`, `table_template`, `schema`, `tags_as_jsonb`, `fields_as_jsonb`)
 4. Explanations of the parameters are commented out with a single `##`
 
 The commented out parameters also show their default values.
 
-For the first example we'll set the address parameter to a proper connection string to establish a connection to an instance of TimescaleDB or PostgreSQL. 
+For the first example we'll set the connection parameter to a proper connection string to establish a connection to an instance of TimescaleDB or PostgreSQL. 
 All the other parameters will have their default values.
 
 ### Creating hypertables
@@ -167,7 +169,7 @@ When we run Telegraf we only need to specify the config file to be used. If we e
 
 ```
 $  telegraf --config telegraf.conf 
-2019-05-23T13:48:09Z I! Starting Telegraf 1.10.4-with-pg
+2019-05-23T13:48:09Z I! Starting Telegraf 1.11.3-with-pg
 2019-05-23T13:48:09Z I! Loaded inputs: cpu
 2019-05-23T13:48:09Z I! Loaded outputs: postgresql
 2019-05-23T13:48:09Z I! Tags enabled: host=local
@@ -340,8 +342,8 @@ Additionally, we have several other [tutorials][] available for you to explore a
 [public-slack]: https://timescaledb.slack.com/
 [mac-build]: https://telegrafreleases.blob.core.windows.net/macos/telegraf
 [windows-build]: https://telegrafreleases.blob.core.windows.net/windows/telegraf.exe
-[deb-build]: https://telegrafreleases.blob.core.windows.net/linux/telegraf_1.10.4~with~pg-1_amd64.deb
-[rpm-build]: https://telegrafreleases.blob.core.windows.net/linux/telegraf-1.10.4~with~pg-1.x86_64.rpm
+[deb-build]: https://telegrafreleases.blob.core.windows.net/linux/telegraf_1.11.3~with~pg-1_amd64.deb
+[rpm-build]: https://telegrafreleases.blob.core.windows.net/linux/telegraf-1.11.3~with~pg-1.x86_64.rpm
 [linux-bin-build]: https://telegrafreleases.blob.core.windows.net/linux/telegraf
 [pull-request]: https://github.com/influxdata/telegraf/pull/3428
 [architecture_lnk]: https://docs.timescale.com/introduction/architecture


### PR DESCRIPTION
The new build of our Telegraf is based on 1.11.3. This commit updates
the references throughout the text and the links for the builds.