### PR TITLE
Fix CentOS 7 install sudo error

### DIFF
--- a/getting-started/installation-yum.md
+++ b/getting-started/installation-yum.md
@@ -32,7 +32,7 @@ Add TimescaleDB's third party repository and install TimescaleDB,
 which will download any dependencies it needs from the PostgreSQL repo:
 ```bash
 # Add our repo
-sudo cat > /etc/yum.repos.d/timescale_timescaledb.repo <<EOL
+sudo tee /etc/yum.repos.d/timescale_timescaledb.repo <<EOL
 [timescale_timescaledb]
 name=timescale_timescaledb
 baseurl=https://packagecloud.io/timescale/timescaledb/el/7/\$basearch


### PR DESCRIPTION
Running just `cat` with superuser privileges results in a permissions error. Using `sudo tee` fixes this.