### PR TITLE
Update install prereqs to reflect latest

### DIFF
--- a/getting-started/installation-apt-debian.md
+++ b/getting-started/installation-apt-debian.md
@@ -2,11 +2,11 @@
 
 This will install TimescaleDB via `apt` on Debian distros.
 
-**Note: TimescaleDB requires PostgreSQL 9.6.3+, 10.2+, or 11.0+**
+**Note: TimescaleDB requires PostgreSQL 9.6.3+, 10.9+, or 11.4+**
 
 #### Prerequisites
 
-- Debian 8 (jessie) or 9 (stretch)
+- Debian 8 (jessie), 9 (stretch), or 10 (buster)
 
 #### Build & Install
 

--- a/getting-started/installation-apt-ubuntu.md
+++ b/getting-started/installation-apt-ubuntu.md
@@ -2,7 +2,7 @@
 
 This will install TimescaleDB via `apt` on Ubuntu distros.
 
-**Note: TimescaleDB requires PostgreSQL 9.6.3+, 10.2+, or 11.0+**
+**Note: TimescaleDB requires PostgreSQL 9.6.3+, 10.9+, or 11.4+**
 
 #### Prerequisites
 

--- a/getting-started/installation-homebrew.md
+++ b/getting-started/installation-homebrew.md
@@ -2,7 +2,7 @@
 
 This will install both TimescaleDB *and* PostgreSQL via Homebrew.
 
-**Note: TimescaleDB requires PostgreSQL 9.6.3+, 10.2+, or 11.0+**
+**Note: TimescaleDB requires PostgreSQL 9.6.3+, 10.9+, or 11.4+**
 
 #### Prerequisites
 

--- a/getting-started/installation-source-windows.md
+++ b/getting-started/installation-source-windows.md
@@ -1,6 +1,6 @@
 ## From Source (Windows) [](installation-source)
 
-**Note: TimescaleDB requires PostgreSQL 9.6.3+, 10.2+, or 11.0+**
+**Note: TimescaleDB requires PostgreSQL 9.6.3+, 10.9+, or 11.4+**
 
 #### Prerequisites
 

--- a/getting-started/installation-source.md
+++ b/getting-started/installation-source.md
@@ -1,6 +1,6 @@
 ## From Source [](installation-source)
 
-**Note: TimescaleDB requires PostgreSQL 9.6.3+, 10.2+, or 11.0+**
+**Note: TimescaleDB requires PostgreSQL 9.6.3+, 10.9+, or 11.4+**
 
 #### Prerequisites
 

--- a/getting-started/installation-windows.md
+++ b/getting-started/installation-windows.md
@@ -1,6 +1,6 @@
 ## Windows ZIP Installer [](installation-windows)
 
-**Note: TimescaleDB requires PostgreSQL 9.6.3+,  10.2+, or 11.0+**
+**Note: TimescaleDB requires PostgreSQL 9.6.3+, 10.9+, or 11.4+**
 
 #### Prerequisites
 

--- a/getting-started/installation-yum.md
+++ b/getting-started/installation-yum.md
@@ -3,7 +3,7 @@
 This will install both TimescaleDB *and* PostgreSQL via `yum`
 (or `dnf` on Fedora).
 
-**Note: TimescaleDB requires PostgreSQL 9.6.3+, 10.2+, or 11.0+**
+**Note: TimescaleDB requires PostgreSQL 9.6.3+, 10.9+, or 11.4+**
 
 #### Prerequisites
 


### PR DESCRIPTION
Since some of our binary builds are built only against 10.9+ and
11.4+, we update the pre-requisites to reflect that. In addition,
we now support Debian 10 (buster).