### PR TITLE
Add a Limitations section

### DIFF
--- a/getting-started/scaling-out.md
+++ b/getting-started/scaling-out.md
@@ -8,10 +8,12 @@ Hypertables handle large amounts of data by breaking it up into
 smaller pieces (chunks), allowing operations to execute
 efficiently. When the amount of data is expected to be beyond what a
 single machine can handle, you can distribute the data chunks over
-several machines by using *distributed hypertables*.  Distributed
-hypertables are similar to normal hypertables, but they add an
-additional layer of hypertable partitioning by distributing chunks
-across *data nodes*.
+several machines by using *distributed hypertables*. There are some
+[limitations][distributed-hypertable-limitations] to using distributed
+hypertables that might be good to review before getting
+started. Distributed hypertables are otherwise similar to normal
+hypertables, but they add an additional layer of hypertable
+partitioning by distributing chunks across *data nodes*.
 
 Data nodes together with an *access node* constitute a distributed database
 ([architecture][]). All the nodes are TimescaleDB instances,
@@ -190,3 +192,4 @@ node.
 [contact]: https://www.timescale.com/contact
 [data-node-authentication]: /getting-started/data-node-authentication
 [max_prepared_transactions]: https://www.postgresql.org/docs/current/runtime-config-resource.html#GUC-MAX-PREPARED-TRANSACTIONS
+[distributed-hypertable-limitations]: /using-timescaledb/limitations#distributed-hypertable-limitations

--- a/page-index/page-index.js
+++ b/page-index/page-index.js
@@ -82,10 +82,10 @@ const pageIndex = [
                 type: PAGE,
                 href: "migrating-data"
             }, {
-            		Title: "Scaling Out",
-            		type: PAGE,
-            		href: "scaling-out"
-      	    }, {
+                    Title: "Scaling Out",
+                    type: PAGE,
+                    href: "scaling-out"
+            }, {
                 type: HIDDEN_REDIRECT,
                 href: "basic-operations",
                 to: "/using-timescaledb/hypertables"
@@ -267,6 +267,11 @@ const pageIndex = [
                 Title: "Telemetry",
                 type: PAGE,
                 href: "telemetry",
+                children: []
+            }, {
+                Title: "Limitations",
+                type: PAGE,
+                href: "limitations",
                 children: []
             }
         ]

--- a/using-timescaledb/limitations.md
+++ b/using-timescaledb/limitations.md
@@ -1,0 +1,47 @@
+# Limitations [](limitations)
+
+While TimescaleDB generally offers capabilities that go beyond what
+PostgreSQL offers, there are some limitations to using hypertables,
+and, in particular, distributed hypertables. This section documents
+the common limitations when using both regular and distributed
+hypertables.
+
+## Hypertable Limitations [](hypertable-limitations)
+
+- Foreign key constraints referencing a hypertable are not supported.
+- Time dimensions (columns) used for partitioning cannot have NULL
+  values.
+- Unique indexes must include all columns that are partitioning
+  dimensions.
+- `UPDATE` statements that move values between partitions (chunks) are
+  not supported. This includes upserts (`INSERT ... ON CONFLICT
+  UPDATE`).
+
+## Distributed Hypertable Limitations [](distributed-hypertable-limitations)
+
+All the limitations of regular hypertables also apply to distributed
+hypertables. In addition, the following limitations apply specifically
+to distributed hypertables:
+
+- Background job scheduling is not supported.
+- Continuous aggregates are not supported.
+- Compressed hypertables are not supported.
+- Reordering chunks is not supported.
+- Tablespaces cannot be attached to a distributed hypertable on the
+  access node. It is still possible attach tablespaces on data nodes.
+- Roles and permissions are assumed to be consistent across the nodes
+  of a distributed database, but consistency is not enforced.
+- Joins on data nodes are not supported. Joining a distributed
+  hypertable with another table requires the other table to reside on
+  the access node. This also limits the performance of joins on
+  distributed hypertables.
+- Tables referenced by foreign key constraints in a distributed
+  hypertable must be present on the access node and all data
+  nodes. This applies also to referenced values.
+- Parallel-aware scans and appends are not supported.
+
+Note that these limitations concern usage from the access node. Some
+currently unsupported features (like background scheduling and
+continuous aggregates) might still work on individual data nodes, but
+such usage is neither tested nor officially supported. Future versions
+of TimescaleDB might remove some of these limitations.


### PR DESCRIPTION
This change adds a section on limitations of both regular and
distributed hypertables under "Using TimescaleDB".