### PR TITLE
Fixing links to authentication page

### DIFF
--- a/getting-started/scaling-out.md
+++ b/getting-started/scaling-out.md
@@ -190,6 +190,6 @@ node.
 [detach_data_node]: /api#detach_data_node
 [timescaledb_information-data_node]: /api#timescaledb_information-data_node
 [contact]: https://www.timescale.com/contact
-[data-node-authentication]: /getting-started/data-node-authentication
+[data-node-authentication]: /getting-started/setup/data-node-authentication
 [max_prepared_transactions]: https://www.postgresql.org/docs/current/runtime-config-resource.html#GUC-MAX-PREPARED-TRANSACTIONS
 [distributed-hypertable-limitations]: /using-timescaledb/limitations#distributed-hypertable-limitations

--- a/tutorials/clustering.md
+++ b/tutorials/clustering.md
@@ -122,3 +122,4 @@ inserted data across multiple data nodes, and queried that data.
 
 [architecture]: /introduction/architecture#timescaledb-clustering
 [contact]: https://www.timescale.com/contact
+[data-node-authentication]: /getting-started/setup/data-node-authentication


### PR DESCRIPTION
One link was pointing to the wrong location for the data node
authentication page, and one was missing altogether.