### PR TITLE
Document set_replication_factor

### DIFF
--- a/api.md
+++ b/api.md
@@ -1235,11 +1235,11 @@ SELECT set_number_partitions('conditions', 2, 'device_id');
 
 ## set_replication_factor() [](set_replication_factor)
 Sets the replication factor of a distributed hypertable to the given value. 
-The setting will affect only new chunks. 
-Newly created chunks of the hypertable will be replicated to different data nodes,
-so the amount of replicas is the same as the replication factor.
+Changing the replication factor does not affect the number of replicas for existing chunks.
+Chunks created after changing the replication factor will be replicated 
+in accordance with new value of the replication factor.
 
-If existing chunks have less replicas than the given replication factor,
+If existing chunks have less replicas than new value of the replication factor,
 the function will print a warning.
 
 #### Required Arguments [](set_replication_factor-required-arguments)

--- a/api.md
+++ b/api.md
@@ -1246,8 +1246,8 @@ the function will print a warning.
 
 |Name|Description|
 |---|---|
-| `main_table` | Identifier of the distributed hypertable to update the replication factor for.|
-| `replication_factor` | The new value of the replication factor. Must be greater than 0.|
+| `main_table` | (REGCLASS) Identifier of the distributed hypertable to update the replication factor for.|
+| `replication_factor` | (INTEGER) The new value of the replication factor. Must be greater than 0.|
 
 #### Sample Usage [](set_replication_factor-examples)
 

--- a/api.md
+++ b/api.md
@@ -1237,7 +1237,9 @@ SELECT set_number_partitions('conditions', 2, 'device_id');
 Sets the replication factor of a distributed hypertable to the given value. 
 Changing the replication factor does not affect the number of replicas for existing chunks.
 Chunks created after changing the replication factor will be replicated 
-in accordance with new value of the replication factor.
+in accordance with new value of the replication factor. If the replication factor cannot be
+satisfied, since the amount of attached data nodes is less than new replication factor, 
+the command aborts with an error.
 
 If existing chunks have less replicas than new value of the replication factor,
 the function will print a warning.
@@ -1246,8 +1248,19 @@ the function will print a warning.
 
 |Name|Description|
 |---|---|
-| `main_table` | (REGCLASS) Identifier of the distributed hypertable to update the replication factor for.|
-| `replication_factor` | (INTEGER) The new value of the replication factor. Must be greater than 0.|
+| `hypertable` | (REGCLASS) Identifier of the distributed hypertable to update the replication factor for.|
+| `replication_factor` | (INTEGER) The new value of the replication factor. Must be greater than 0, 
+and smaller than or equal to the number of attached data nodes.|
+
+#### Errors
+
+An error will be given if:
+- `hypertable` is not a distributed hypertable.
+- `replication_factor` is less than `1`, which cannot be set on a distributed hypertable.
+- `replication_factor` is bigger than the number of attached data ndoes.
+
+If the bigger replication factor is desired, it is necessary to attach more data nodes 
+by using [attach_data_node](#attach_data_node).
 
 #### Sample Usage [](set_replication_factor-examples)
 
@@ -1262,6 +1275,13 @@ WARNING:  hypertable "conditions" is under-replicated
 DETAIL:  Some chunks have less than 2 replicas.
 ```
 
+Example of providing too big replication factor for a hypertable with 2 attached data nodes:
+```sql
+SELECT set_replication_factor('conditions', 3);
+ERROR:  too big replication factor for hypertable "conditions"
+DETAIL:  The hypertable has 2 data nodes attached, while the replication factor is 3.
+HINT:  Decrease the replication factor or attach more data nodes to the hypertable.
+```
 
 ---
 

--- a/api.md
+++ b/api.md
@@ -1249,8 +1249,7 @@ the function will print a warning.
 |Name|Description|
 |---|---|
 | `hypertable` | (REGCLASS) Identifier of the distributed hypertable to update the replication factor for.|
-| `replication_factor` | (INTEGER) The new value of the replication factor. Must be greater than 0, 
-and smaller than or equal to the number of attached data nodes.|
+| `replication_factor` | (INTEGER) The new value of the replication factor. Must be greater than 0, and smaller than or equal to the number of attached data nodes.|
 
 #### Errors
 

--- a/api.md
+++ b/api.md
@@ -43,6 +43,7 @@
 > - [set_adaptive_chunking](#set_adaptive_chunking)
 > - [set_chunk_time_interval](#set_chunk_time_interval)
 > - [set_number_partitions](#set_number_partitions)
+> - [set_replication_factor](#set_replication_factor)
 > - [show_chunks](#show_chunks)
 > - [show_tablespaces](#show_tablespaces)
 > - [time_bucket](#time_bucket)
@@ -1228,6 +1229,39 @@ For a table with more than one space dimension:
 ```sql
 SELECT set_number_partitions('conditions', 2, 'device_id');
 ```
+
+
+---
+
+## set_replication_factor() [](set_replication_factor)
+Sets the replication factor of a distributed hypertable to the given value. 
+The setting will affect only new chunks. 
+Newly created chunks of the hypertable will be replicated to different data nodes,
+so the amount of replicas is the same as the replication factor.
+
+If existing chunks have less replicas than the given replication factor,
+the function will print a warning.
+
+#### Required Arguments [](set_replication_factor-required-arguments)
+
+|Name|Description|
+|---|---|
+| `main_table` | Identifier of the distributed hypertable to update the replication factor for.|
+| `replication_factor` | The new value of the replication factor. Must be greater than 0.|
+
+#### Sample Usage [](set_replication_factor-examples)
+
+Update the replication factor for a distributed hypertable to `2`:
+```sql
+SELECT set_replication_factor('conditions', 2);
+```
+
+Example of the warning if any existing chunk of the distributed hypertable has less than 2 replicas:
+```
+WARNING:  hypertable "conditions" is under-replicated
+DETAIL:  Some chunks have less than 2 replicas.
+```
+
 
 ---
 

--- a/api.md
+++ b/api.md
@@ -1258,7 +1258,7 @@ An error will be given if:
 - `replication_factor` is less than `1`, which cannot be set on a distributed hypertable.
 - `replication_factor` is bigger than the number of attached data ndoes.
 
-If the bigger replication factor is desired, it is necessary to attach more data nodes 
+If a bigger replication factor is desired, it is necessary to attach more data nodes 
 by using [attach_data_node](#attach_data_node).
 
 #### Sample Usage [](set_replication_factor-examples)
@@ -1274,7 +1274,7 @@ WARNING:  hypertable "conditions" is under-replicated
 DETAIL:  Some chunks have less than 2 replicas.
 ```
 
-Example of providing too big replication factor for a hypertable with 2 attached data nodes:
+Example of providing too big of a replication factor for a hypertable with 2 attached data nodes:
 ```sql
 SELECT set_replication_factor('conditions', 3);
 ERROR:  too big replication factor for hypertable "conditions"


### PR DESCRIPTION
Adds documentation of multinode function set_replication_factor.

Closes https://github.com/timescale/docs.timescale.com-content/issues/275