### PR TITLE
Add note about deadlock during create_hypertable

### DIFF
--- a/api.md
+++ b/api.md
@@ -295,7 +295,8 @@ converting table itself.
 The deadlock might abort `create_hypertable`. 
 >
 >The deadlock can be prevented by manually obtaining `SHARE ROW EXCLUSIVE` lock 
-on the referenced tables before calling `create_hypertable` in the same transaction.
+on the referenced tables before calling `create_hypertable` in the same transaction,
+see [PostgreSQL documentation][postgres-lock] for the syntax.
 <!-- -->
 
 #### Units [](create_hypertable-units)
@@ -2803,6 +2804,7 @@ and then inspect `dump_file.txt` before sending it together with a bug report or
 [postgres-createtablespace]: https://www.postgresql.org/docs/current/sql-createtablespace.html
 [postgres-cluster]: https://www.postgresql.org/docs/current/sql-cluster.html
 [postgres-altertable]: https://www.postgresql.org/docs/current/sql-altertable.html
+[postgres-lock]: https://www.postgresql.org/docs/current/sql-lock.html
 [migrate-from-postgresql]: /getting-started/migrating-data
 [memory-units]: https://www.postgresql.org/docs/current/static/config-setting.html#CONFIG-SETTING-NAMES-VALUES
 [telemetry]: /using-timescaledb/telemetry

--- a/api.md
+++ b/api.md
@@ -289,7 +289,7 @@ columns, but the reverse is not allowed. UNIQUE and PRIMARY constraints must inc
 partitioning key.
 
 >:WARNING: Running `create_hypertable` with data migration on a table with foreign key contraints to other tables 
-might result in a deadlock if parallel transactions simulteniously try to insert data into the table and 
+might result in a deadlock if parallel transactions simultaneously try to insert data into the table and 
 the referenced tables. This can result in aborting `create_hypertable`. The deadlock can be prevented by 
 manually obtaining `SHARE ROW EXCLUSIVE` lock on the referenced tables  before calling `create_hypertable` 
 in the same transaction.

--- a/api.md
+++ b/api.md
@@ -288,10 +288,11 @@ to how you handle constraints. A hypertable can contain foreign keys to normal S
 columns, but the reverse is not allowed. UNIQUE and PRIMARY constraints must include the
 partitioning key.
 
->:WARNING: Running `create_hypertable` with the data migration on a table with foreign key contraints 
-might result in a deadlock. This is likely to happen if parallel transactions simultaneously try 
-to insert data into tables referenced from the converting table and into the converting table itself. 
-The deadlock can abort `create_hypertable`. 
+>:TIP: Running `create_hypertable` with the data migration on a table with foreign key contraints 
+might result in a deadlock. This is likely to happen when concurrent transactions simultaneously try 
+to insert data into tables, which are referenced in the foreign key constraints, and into the
+converting table itself. 
+The deadlock might abort `create_hypertable`. 
 >
 >The deadlock can be prevented by manually obtaining `SHARE ROW EXCLUSIVE` lock 
 on the referenced tables before calling `create_hypertable` in the same transaction.

--- a/api.md
+++ b/api.md
@@ -278,7 +278,8 @@ as a table with column headings.
 
 >:WARNING: The use of the `migrate_data` argument to convert a non-empty table can
 lock the table for a significant amount of time, depending on how much data is
-in the table.
+in the table. It can also run into deadlock if foreign key constraints exist to other
+tables.
 >
 >If you would like finer control over index formation and other aspects
     of your hypertable, [follow these migration instructions instead][migrate-from-postgresql].
@@ -287,14 +288,10 @@ in the table.
 to how you handle constraints. A hypertable can contain foreign keys to normal SQL table
 columns, but the reverse is not allowed. UNIQUE and PRIMARY constraints must include the
 partitioning key.
-
->:TIP: Running `create_hypertable` with the data migration on a table with foreign key contraints 
-might result in a deadlock. This is likely to happen when concurrent transactions simultaneously try 
-to insert data into tables, which are referenced in the foreign key constraints, and into the
-converting table itself. 
-The deadlock might abort `create_hypertable`. 
 >
->The deadlock can be prevented by manually obtaining `SHARE ROW EXCLUSIVE` lock 
+>The deadlock is likely to happen when concurrent transactions simultaneously try 
+to insert data into tables that are referenced in the foreign key constraints, and into the
+converting table itself. The deadlock can be prevented by manually obtaining `SHARE ROW EXCLUSIVE` lock 
 on the referenced tables before calling `create_hypertable` in the same transaction,
 see [PostgreSQL documentation][postgres-lock] for the syntax.
 <!-- -->

--- a/api.md
+++ b/api.md
@@ -290,7 +290,7 @@ columns, but the reverse is not allowed. UNIQUE and PRIMARY constraints must inc
 partitioning key.
 >
 >The deadlock is likely to happen when concurrent transactions simultaneously try 
-to insert data into tables that are referenced in the foreign key constraints, and into the
+to insert data into tables that are referenced in the foreign key constraints and into the
 converting table itself. The deadlock can be prevented by manually obtaining `SHARE ROW EXCLUSIVE` lock 
 on the referenced tables before calling `create_hypertable` in the same transaction,
 see [PostgreSQL documentation][postgres-lock] for the syntax.

--- a/api.md
+++ b/api.md
@@ -287,6 +287,12 @@ in the table.
 to how you handle constraints. A hypertable can contain foreign keys to normal SQL table
 columns, but the reverse is not allowed. UNIQUE and PRIMARY constraints must include the
 partitioning key.
+
+>:WARNING: Running `create_hypertable` with data migration on a table with foreign key contraints to other tables 
+might result in a deadlock if parallel transactions simulteniously try to insert data into the table and 
+the referenced tables. This can result in aborting `create_hypertable`. The deadlock can be prevented by 
+manually obtaining `SHARE ROW EXCLUSIVE` lock on the referenced tables  before calling `create_hypertable` 
+in the same transaction.
 <!-- -->
 
 #### Units [](create_hypertable-units)

--- a/api.md
+++ b/api.md
@@ -288,11 +288,13 @@ to how you handle constraints. A hypertable can contain foreign keys to normal S
 columns, but the reverse is not allowed. UNIQUE and PRIMARY constraints must include the
 partitioning key.
 
->:WARNING: Running `create_hypertable` with data migration on a table with foreign key contraints to other tables 
-might result in a deadlock if parallel transactions simultaneously try to insert data into the table and 
-the referenced tables. This can result in aborting `create_hypertable`. The deadlock can be prevented by 
-manually obtaining `SHARE ROW EXCLUSIVE` lock on the referenced tables  before calling `create_hypertable` 
-in the same transaction.
+>:WARNING: Running `create_hypertable` with the data migration on a table with foreign key contraints 
+might result in a deadlock. This is likely to happen if parallel transactions simultaneously try 
+to insert data into tables referenced from the converting table and into the converting table itself. 
+The deadlock can abort `create_hypertable`. 
+>
+>The deadlock can be prevented by manually obtaining `SHARE ROW EXCLUSIVE` lock 
+on the referenced tables before calling `create_hypertable` in the same transaction.
 <!-- -->
 
 #### Units [](create_hypertable-units)


### PR DESCRIPTION
Adds warning of deadlocking during `create_hypertable` for tables with foreign key constraints.

Closes https://github.com/timescale/timescaledb/pull/1677