### PR TITLE
Add section on integer-based continuous aggregates

### DIFF
--- a/page-index/page-index.js
+++ b/page-index/page-index.js
@@ -383,6 +383,10 @@ const pageIndex = [
                         type: ANCHOR,
                         href: "#dropping-data"
                     }, {
+                        Title: "Advanced Topics",
+                        type: ANCHOR,
+                        href: "#advanced-usage"
+                    }, {
                         Title: "Best Practices",
                         type: ANCHOR,
                         href: "#best-practices"

--- a/tutorials/continuous-aggs-tutorial.md
+++ b/tutorials/continuous-aggs-tutorial.md
@@ -156,23 +156,14 @@ aggregates only for the data that satisfies the condition:
 `time_bucket('1h', pickup_datetime) < max(pickup_time) - '1h'` (if the
 `refresh_lag` is set to 1 hour)
 
-Both `refresh_lag` or `refresh_interval` can be set to an integer
-value, which is then interpreted as the number of microseconds for the
-lag or interval respectively.
-
-To keep the continuous aggregate up-to-date,
-you can set `timescaledb.refresh_lag` to a negative value. This will allow the continuous aggregate
-to update when new data comes in. However, do note that this comes with performance implications,
-since the aggregate query will be run more often. 
-
 The `timescaledb.max_interval_per_job` parameter is used when we want to limit
 the amount of data processed by an update of the continuous aggregate and use
 smaller or bigger batch sizes (the batching is done automatically by TimescaleDB).
 `timescaledb.max_interval_per_job` specifies the batch size.
 
-`refresh_lag` and `max_interval_per_job` are additional parameters that can be
-specified while creating or altering a continuous aggregate. Refer to the
-documentation for the syntax.
+The parameters `refresh_lag` and `max_interval_per_job` can be
+specified while creating or altering a continuous aggregate. Refer to
+the documentation for the syntax.
 
 The `timescaledb.ignore_invalidation_older_than` parameter is used
 when you want to avoid updating a continuous aggregate when modifying
@@ -249,13 +240,6 @@ refresh_lag                | 01:00:00
 refresh_interval           | 00:30:00
 max_interval_per_job       | 20:00:00
 materialization_hypertable | _timescaledb_internal._materialized_hypertable_2
-```
-
-We can also manually update the continuous aggregate query by using the
-`REFRESH` command.
-
-``` sql
-REFRESH MATERIALIZED VIEW cagg_rides_view;
 ```
 
 You will find more details about the API in the [documentation][tsdb_doc].

--- a/using-timescaledb/continuous-aggregates.md
+++ b/using-timescaledb/continuous-aggregates.md
@@ -159,10 +159,10 @@ aggregate and the aggregate has to be updated.
 
 By default, all modifications trigger a update of the continuous
 aggregate. If the `ignore_invalidation_older_than` parameter is set to
-a duration, modifications with a timestamp that is older will be
-ignored and not trigger an update of the continuous aggregate. As a
-result, refresh jobs will complete faster since they are only dealing
-with new data as part of the refresh.
+a duration, modifications with an older time will be ignored and not
+trigger an update of the continuous aggregate. As a result, refresh
+jobs will complete faster since they are only dealing with new data as
+part of the refresh.
 
 A common use case is to drop the raw data from the hypertable and just
 keep the downsampled data in the continuous aggregate. So, for
@@ -180,10 +180,6 @@ SELECT drop_chunks(INTERVAL '30 days', 'device_readings')
 
 You can read more about data retention with continuous aggregates in
 the [*Data retention*][sec-data-retention] section.
-
->:TIP: Most times the continuous aggregate view will be updated by the background job;
-  however, if you would like to run it yourself, you may use the
-  [`REFRESH MATERIALIZED VIEW` command][api-refresh-continuous-aggs].
 
 **Using `timescaledb.information` Views:**
 The various options used to create the continuous aggregate view, as well as its
@@ -245,6 +241,108 @@ dropped.
 The same argument must also be supplied to the [`add_drop_chunks_policy`
 function][api-add-drop-chunks] when creating a data retention policy for a
 hypertable with a continuous aggregate.  
+
+---
+
+### Advanced Topics [](advanced-usage)
+
+#### Continuous Aggregates using Integer-Based Time [](create-integer)
+
+Usually, continuous aggregates are defined on a [date/time-type](https://www.postgresql.org/docs/current/datatype-datetime.html) column, but it is
+also possible to create your own custom scheme for handling
+aggregation for tables that are using an integer time
+column. This can be useful if you have tables that use other measures
+of time that can be represented as integer values, such as nanosecond
+epochs, minutes since founding date, or whatever is suitable for your
+application.
+
+As an example, suppose that you have a table with CPU and disk usage
+for some devices where time is measured in
+[microfortnights][fff-system] (a microfortnight is a little more than
+a second). Since you are using an integer-valued column as time, you
+need to provide the chunk time interval when creating the
+hypertable. In this case, let each chunk consist of a millifortnight
+(a 1000 microfortnights, which is about 20 minutes).
+
+```sql
+CREATE TABLE devices(
+  time BIGINT,        -- Time in microfortnights since epoch
+  cpu_usage INTEGER,  -- Total CPU usage
+  disk_usage INTEGER, -- Total disk usage
+  PRIMARY KEY (time)
+);
+
+SELECT create_hypertable('devices', 'time',
+                         chunk_time_interval => 1000);
+```
+
+To define a continuous aggregate on a hypertable that is using an
+integer time dimension, it is necessary to have a function to get the
+current time in whatever representation that you are using and set it
+for the hypertable using
+[`set_integer_now_func`][api-set-integer-now-func]. The function can
+be defined as a normal PostgreSQL function, but needs to be
+[`STABLE`][pg-func-stable], take no arguments, and return an integer
+value of the same type as the time column in the table. In our case,
+this should suffice:
+
+```sql
+CREATE FUNCTION current_microfortnight() RETURNS BIGINT
+LANGUAGE SQL STABLE AS $$
+	SELECT CAST(1209600 * EXTRACT(EPOCH FROM CURRENT_TIME) / 1000000 AS BIGINT)
+$$;
+
+SELECT set_integer_now_func('devices', 'current_microfortnight');
+```
+
+Once the replacement for current time has been set up, you can define
+a continuous aggregate for the `devices` table.
+
+```sql
+CREATE VIEW devices_summary
+WITH (timescaledb.continuous) AS
+SELECT time_bucket('500', time) AS bucket,
+       avg(cpu_usage) AS avg_cpu,
+       avg(disk_usage) AS avg_disk
+     FROM devices
+     GROUP BY bucket;
+```
+
+You can now insert some rows to check if the aggregation works as
+expected.
+
+```sql
+CREATE EXTENSION tablefunc;
+
+INSERT INTO devices(time, cpu_usage, disk_usage)
+SELECT time,
+       normal_rand(1,70,10) AS cpu_usage,
+	   normal_rand(1,2,1) * (row_number() over()) AS disk_usage
+  FROM generate_series(1,10000) AS time;
+```
+
+>:TIP: You can use the `tablefunc` extension to generate a normal
+>distribution and use the `row_number` function to turn it into a
+>cumulative sequence.
+
+You can now check that the view contains the correct data. 
+
+```sql
+postgres=# SELECT * FROM devices_summary ORDER BY bucket LIMIT 10;
+ bucket |       avg_cpu       |       avg_disk
+--------+---------------------+----------------------
+      0 | 63.0000000000000000 |   6.0000000000000000
+      5 | 69.8000000000000000 |   9.6000000000000000
+     10 | 70.8000000000000000 |  24.0000000000000000
+     15 | 75.8000000000000000 |  37.6000000000000000
+     20 | 71.6000000000000000 |  26.8000000000000000
+     25 | 67.6000000000000000 |  56.0000000000000000
+     30 | 68.8000000000000000 |  90.2000000000000000
+     35 | 71.6000000000000000 |  88.8000000000000000
+     40 | 66.4000000000000000 |  81.2000000000000000
+     45 | 68.2000000000000000 | 106.0000000000000000
+(10 rows)
+```
 
 ---
 
@@ -365,15 +463,17 @@ compute the number of distinct items in a set, are not supported by continuous
 aggregates. However, many of these types of functions have parallelizable approximations
 that can provide quite accurate approximations of the actual result and would therefore
 be able to integrate seamlessly with the continuous aggregates project. We intend to
-implement a number of these aggregates.  
+implement a number of these aggregates.
 
 ---
 
 
+[fff-system]: https://en.wikipedia.org/wiki/FFF_system
 [sec-data-retention]: /using-timescaledb/data_retention#data-retention
 [postgres-materialized-views]: https://www.postgresql.org/docs/current/rules-materializedviews.html
 [api-continuous-aggs]:/api#continuous-aggregates
 [postgres-createview]: https://www.postgresql.org/docs/current/static/sql-createview.html
+[pg-func-stable]: https://www.postgresql.org/docs/current/static/sql-createfunction.html
 [time-bucket]: /api#time_bucket
 [api-continuous-aggs-create]: /api#continuous_aggregate-create_view
 [postgres-parallel-agg]:https://www.postgresql.org/docs/current/parallel-plans.html#PARALLEL-AGGREGATION
@@ -382,6 +482,7 @@ implement a number of these aggregates.
 [api-continuous-aggregate-stats]: /api#timescaledb_information-continuous_aggregate_stats
 [api-drop-chunks]: /api#drop_chunks
 [api-set-chunk-interval]: /api#set_chunk_time_interval
+[api-set-integer-now-func]: /api#set_integer_now_func
 [api-add-drop-chunks]: /api#add_drop_chunks_policy
 [timescale-github]: https://github.com/timescale/timescaledb
 [support-slack]: https://slack-login.timescale.com


### PR DESCRIPTION
A section on integer-based continuous aggregates is added with some
examples on how to define a view using a custom-defined time interval.

Subtask of timescale/timescaledb-private#609