### PR TITLE
Deprecate PG9.6 and PG10 for 1.7.0

### DIFF
--- a/getting-started/configuring.md
+++ b/getting-started/configuring.md
@@ -99,11 +99,15 @@ point in time. You need a background worker allocated to each database to run
 a lightweight scheduler that schedules jobs. On top of that, any additional
 workers you allocate here will run background jobs when needed.
 
-For larger queries, PostgreSQL automatically uses parallel workers if they are
-available. To configure this on PostgreSQL 10+, use the `max_parallel_workers`
-setting; for PostgreSQL 9.6, nothing needs to be done.
-Increasing this setting will improve query performance for larger queries.
-Smaller queries may not trigger parallel workers.
+For larger queries, PostgreSQL automatically uses parallel workers if
+they are available. To configure this on PostgreSQL 10 or later, use
+the `max_parallel_workers` setting; for PostgreSQL 9.6, nothing needs
+to be done. Increasing this setting will improve query performance for
+larger queries.  Smaller queries may not trigger parallel workers.
+
+>:WARNING: Support for PostgresSQL 9.6 and 10 is deprecated and will
+>be removed in a future release. We recommend that you use at least
+>PostgreSQL 11.4 or 12.0.
 
 Finally, you must configure `max_worker_processes` to be at least the sum of
 `timescaledb.max_background_workers` and `max_parallel_workers`.

--- a/getting-started/installation-apt-debian.md
+++ b/getting-started/installation-apt-debian.md
@@ -2,7 +2,9 @@
 
 This will install TimescaleDB via `apt` on Debian distros.
 
-**Note: TimescaleDB requires PostgreSQL 9.6.3+, 10.9+, or 11.4+**
+**Note: TimescaleDB requires PostgreSQL 11.4+ or 12.0+. Support for
+PostgreSQL 9.6.3+ and 10.9+ is deprecated and will be removed in a
+future release.**
 
 #### Prerequisites
 

--- a/getting-started/installation-apt-ubuntu.md
+++ b/getting-started/installation-apt-ubuntu.md
@@ -2,7 +2,9 @@
 
 This will install TimescaleDB via `apt` on Ubuntu distros.
 
-**Note: TimescaleDB requires PostgreSQL 9.6.3+, 10.9+, or 11.4+**
+**Note: TimescaleDB requires PostgreSQL 11.4+ or 12.0+. Support for
+PostgreSQL 9.6.3+ and 10.9+ is deprecated and will be removed in a
+future release.**
 
 #### Prerequisites
 

--- a/getting-started/installation-homebrew.md
+++ b/getting-started/installation-homebrew.md
@@ -2,7 +2,9 @@
 
 This will install both TimescaleDB *and* PostgreSQL via Homebrew.
 
-**Note: TimescaleDB requires PostgreSQL 9.6.3+, 10.9+, or 11.4+**
+**Note: TimescaleDB requires PostgreSQL 11.4+ or 12.0+. Support for
+PostgreSQL 9.6.3+ and 10.9+ is deprecated and will be removed in a
+future release.**
 
 #### Prerequisites
 
@@ -44,9 +46,6 @@ parallelism, and other settings.
 
 To get started you'll now need to restart PostgreSQL and add
 a `postgres` superuser (used in the rest of the docs):
->:WARNING: If you are still on PostgreSQL 9.6 or 10 via Homebrew, you should
-replace `postgresql` with <code>postgresql&#64;9.6</code> for 9.6 or
-<code>postgresql&#64;10</code> for 10.
 
 ```bash
 # Restart PostgreSQL instance

--- a/getting-started/installation-source-windows.md
+++ b/getting-started/installation-source-windows.md
@@ -1,6 +1,8 @@
 ## From Source (Windows) [](installation-source)
 
-**Note: TimescaleDB requires PostgreSQL 9.6.3+, 10.9+, or 11.4+**
+**Note: TimescaleDB requires PostgreSQL 11.4+ or 12.0+. Support for
+PostgreSQL 9.6.3+ and 10.9+ is deprecated and will be removed in a
+future release.**
 
 #### Prerequisites
 

--- a/getting-started/installation-source.md
+++ b/getting-started/installation-source.md
@@ -1,6 +1,8 @@
 ## From Source [](installation-source)
 
-**Note: TimescaleDB requires PostgreSQL 9.6.3+, 10.9+, or 11.4+**
+**Note: TimescaleDB requires PostgreSQL 11.4+ or 12.0+. Support for
+PostgreSQL 9.6.3+ and 10.9+ is deprecated and will be removed in a
+future release.**
 
 #### Prerequisites
 

--- a/getting-started/installation-windows.md
+++ b/getting-started/installation-windows.md
@@ -1,6 +1,8 @@
 ## Windows ZIP Installer [](installation-windows)
 
-**Note: TimescaleDB requires PostgreSQL 9.6.3+, 10.9+, or 11.4+**
+**Note: TimescaleDB requires PostgreSQL 11.4 or 12.0+. Support for
+PostgreSQL 9.6.3+ and 10.9+ is deprecated and will be removed in a
+future release.**
 
 #### Prerequisites
 

--- a/getting-started/installation-yum.md
+++ b/getting-started/installation-yum.md
@@ -3,7 +3,9 @@
 This will install both TimescaleDB *and* PostgreSQL via `yum`
 (or `dnf` on Fedora).
 
-**Note: TimescaleDB requires PostgreSQL 9.6.3+, 10.9+, or 11.4+**
+**Note: TimescaleDB requires PostgreSQL 11.4+ or 12.0+. Support for
+PostgreSQL 9.6.3+ and 10.9+ is deprecated and will be removed in a
+future release.**
 
 #### Prerequisites
 


### PR DESCRIPTION
PG9.6 and PG10 are deprecated for TimescaleDB version 1.7.0 so we
remove documentation describing installation and usage with anything
before PG11.4.

Subtask of timescale/timescaledb-private#609