### PR TITLE
Use constant notation for constants

### DIFF
--- a/introduction/timescaledb-vs-postgres.md
+++ b/introduction/timescaledb-vs-postgres.md
@@ -171,7 +171,7 @@ SELECT time_bucket('3 hours', time) AS period
     first(price, time) AS opening, last(price, time) AS closing,
     max(price) AS high, min(price) AS low
   FROM prices
-  WHERE time > NOW() - interval '7 days'
+  WHERE time > NOW() - INTERVAL '7 days'
   GROUP BY period, asset_code
   ORDER BY period DESC, asset_code;
 ```
@@ -219,7 +219,7 @@ TimescaleDB allows efficient deletion of old data at the **chunk** level,
 rather than at the row level, via its `drop_chunks` functionality.
 
 ```sql
-SELECT drop_chunks(interval '7 days', 'conditions');
+SELECT drop_chunks(INTERVAL '7 days', 'conditions');
 ```
 
 This will delete all chunks (files) from the hypertable 'conditions'

--- a/tutorials/prometheus-adapter.md
+++ b/tutorials/prometheus-adapter.md
@@ -352,7 +352,7 @@ SQL:
 SELECT time_bucket('5 minutes', time) AS five_min_bucket, name, avg(value)
 FROM metrics
 WHERE (name='node_load5' OR name='node_memory_Active_bytes') AND
-      time > NOW() - interval '1 day'
+      time > NOW() - INTERVAL '1 day'
 GROUP BY five_min_bucket,name
 ORDER BY five_min_bucket;
 ```
@@ -374,7 +374,7 @@ SELECT time_bucket('1 hour', m.time) AS hour_bucket,
        m.labels->>'host', h.kernel_updated, AVG(value)
 FROM metrics m LEFT JOIN hosts h on h.host = m.labels->>'host'
 AND  time_bucket('1 hour', m.time) = time_bucket('1 hour', h.kernel_updated)
-WHERE m.name='node_load5' AND m.time > NOW() - interval '7 days'
+WHERE m.name='node_load5' AND m.time > NOW() - INTERVAL '7 days'
 GROUP BY hour_bucket, m.labels->>'host', h.kernel_updated
 ORDER BY hour_bucket;
 ```

--- a/tutorials/telegraf-output-plugin.md
+++ b/tutorials/telegraf-output-plugin.md
@@ -158,7 +158,7 @@ for the name of the table and the column definitions.
 Let's update `table_template` in the config for TimescaleDB:
 
 ```
-  table_template=`CREATE TABLE IF NOT EXISTS {TABLE}({COLUMNS}); SELECT create_hypertable({TABLELITERAL},'time',chunk_time_interval := '1 week'::interval,if_not_exists := true);`
+  table_template=`CREATE TABLE IF NOT EXISTS {TABLE}({COLUMNS}); SELECT create_hypertable({TABLELITERAL},'time',chunk_time_interval := INTERVAL '1 week',if_not_exists := true);`
 ```
 
 This way when a new table is created it is converted into a hypertable, with each chunk holding 1 week intervals. Nothing else is needed to use the plugin with TimescaleDB.

--- a/tutorials/tutorial-forecasting.md
+++ b/tutorials/tutorial-forecasting.md
@@ -54,7 +54,7 @@ WITH data AS (
     ),
     period AS (
   SELECT time_bucket('1 hour', no_gaps) one_hour
-  FROM  generate_series('2016-01-01 00:00:00'::timestamp, '2016-01-31 23:59:59', '1 hour') no_gaps
+  FROM  generate_series(TIMESTAMP '2016-01-01 00:00:00', TIMESTAMP '2016-01-31 23:59:59', INTERVAL '1 hour') no_gaps
      )
 INSERT INTO rides_count
   SELECT period.one_hour, coalesce(data.count, 0)

--- a/using-timescaledb/compression.md
+++ b/using-timescaledb/compression.md
@@ -255,7 +255,7 @@ is named 'conditions', and we are looking for the chunks associated with this hy
 with data older than three days.
 
 ``` sql
-SELECT show_chunks('conditions', older_than => interval '3 days');
+SELECT show_chunks('conditions', older_than => INTERVAL '3 days');
 ```
 
 ||show_chunks|

--- a/using-timescaledb/move_chunk.md
+++ b/using-timescaledb/move_chunk.md
@@ -63,7 +63,7 @@ To determine which chunks to move, we can list chunks that fit a specific criter
 For example,  to identify chunks older than two days:
 
 ```sql
-SELECT show_chunks('conditions', older_than => interval '2 days');
+SELECT show_chunks('conditions', older_than => INTERVAL '2 days');
 ```
 
 In this example, we will move  `_timescaledb_internal._hyper_1_4_chunk` along with

--- a/using-timescaledb/reading-data.md
+++ b/using-timescaledb/reading-data.md
@@ -18,7 +18,7 @@ SELECT * FROM conditions ORDER BY time DESC LIMIT 100;
 
 -- Return the number of data entries written in past 12 hours
 SELECT COUNT(*) FROM conditions
-  WHERE time > NOW() - interval '12 hours';
+  WHERE time > NOW() - INTERVAL '12 hours';
 ```
 To more advanced SQL queries:
 
@@ -30,7 +30,7 @@ SELECT time_bucket('15 minutes', time) AS fifteen_min,
     MAX(temperature) AS max_temp,
     MAX(humidity) AS max_hum
   FROM conditions
-  WHERE time > NOW() - interval '3 hours'
+  WHERE time > NOW() - INTERVAL '3 hours'
   GROUP BY fifteen_min, location
   ORDER BY fifteen_min DESC, max_temp DESC;
 
@@ -41,7 +41,7 @@ SELECT COUNT(DISTINCT location) FROM conditions
   JOIN locations
     ON conditions.location = locations.location
   WHERE locations.air_conditioning = True
-    AND time > NOW() - interval '1 day'
+    AND time > NOW() - INTERVAL '1 day'
 ```
 
 ---
@@ -90,7 +90,7 @@ SELECT time, AVG(temperature) OVER(ORDER BY time
       ROWS BETWEEN 9 PRECEDING AND CURRENT ROW)
     AS smooth_temp
   FROM conditions
-  WHERE location = 'garage' and time > NOW() - interval '1 day'
+  WHERE location = 'garage' and time > NOW() - INTERVAL '1 day'
   ORDER BY time DESC;
 ```
 
@@ -113,7 +113,7 @@ SELECT
     END
   ) AS "bytes"
   FROM net
-  WHERE interface = 'eth0' AND time > NOW() - interval '1 day'
+  WHERE interface = 'eth0' AND time > NOW() - INTERVAL '1 day'
   WINDOW w AS (ORDER BY time)
   ORDER BY time
 ```
@@ -139,7 +139,7 @@ SELECT
     END
   ) / extract(epoch from time - lag(time) OVER w) AS "bytes_per_second"
   FROM net
-  WHERE interface = 'eth0' AND time > NOW() - interval '1 day'
+  WHERE interface = 'eth0' AND time > NOW() - INTERVAL '1 day'
   WINDOW w AS (ORDER BY time)
   ORDER BY time
 ```
@@ -209,7 +209,7 @@ values in the stated range and the last is for values above 85.
 SELECT location, COUNT(*),
     histogram(temperature, 60.0, 85.0, 5)
    FROM conditions
-   WHERE time > NOW() - interval '7 days'
+   WHERE time > NOW() - INTERVAL '7 days'
    GROUP BY location;
 ```
 This query will output data in the following form:
@@ -295,11 +295,11 @@ Note that we can do basic arithmetic operations on intervals easily in order to 
 value to pass to time_bucket.
 ```sql
 SELECT
-  time_bucket_gapfill(interval '2 weeks' / 1080, time, now() - interval '2 weeks', now()) AS btime,
+  time_bucket_gapfill(INTERVAL '2 weeks' / 1080, time, now() - INTERVAL '2 weeks', now()) AS btime,
   sum(volume) AS volume
 FROM trades
 WHERE asset_code = 'TIMS'
-  AND time >= now() - interval '2 weeks' AND time < now()
+  AND time >= now() - INTERVAL '2 weeks' AND time < now()
 GROUP BY btime
 ORDER BY btime;
 ```
@@ -330,12 +330,12 @@ value.
 
 ```sql
 SELECT
-  time_bucket_gapfill('5 min'::interval, time, now() - '2 weeks'::interval, now()) as 5min,
+  time_bucket_gapfill(INTERVAL '5 min', time, now() - INTERVAL '2 weeks', now()) as 5min,
   meter_id,
   locf(avg(data_value)) AS data_value
 FROM my_hypertable
 WHERE
-  time > now() - '2 weeks'::interval
+  time > now() - INTERVAL '2 weeks'
   AND meter_id IN (1,2,3,4)
 GROUP BY 5min, meter_id
 ```

--- a/using-timescaledb/writing-data.md
+++ b/using-timescaledb/writing-data.md
@@ -178,7 +178,7 @@ down to the appropriate chunks that comprise the hypertable.
 ```sql
 DELETE FROM conditions WHERE temperature < 35 OR humidity < 60;
 
-DELETE FROM conditions WHERE time < NOW() - interval '1 month';
+DELETE FROM conditions WHERE time < NOW() - INTERVAL '1 month';
 ```
 
 After running a large `DELETE` operation, users are recommended to


### PR DESCRIPTION
There is a mixture of using constant notation and cast notation for
constants, and this commit fixes that by consistenty using constant
notation.