### PR TITLE
Add PostgreSQL 12 as installation option

### DIFF
--- a/page-index/page-index.js
+++ b/page-index/page-index.js
@@ -47,7 +47,7 @@ const pageIndex = [
                 Title: "Installing",
                 type: REACT_PAGE,
                 href: "installation",
-                options: {pg_version: ["11", "10", "9.6"]},
+                options: {pg_version: ["12", "11", "10", "9.6"]},
                 component: "InstallationPage",
                 children: [
                     {


### PR DESCRIPTION
1.7.0 includes binaries for PG 12, thus the option should be available to users.

Fixes #373