### PR TITLE
[feature]Add basic pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,0 +1,28 @@
+---
+name: Pull request
+about: updating docs content
+title: ""
+labels: 'add-to-branches'
+assignees: ''
+
+---
+
+**Add label for the earliest DB version your changes apply to -->>**
+
+**If you are changing page names or in-page anchors, you must update the
+`page-index.js` file**
+
+**The default reviewers (CODEOWNERS) are added to each PR.  They will
+primarily be reviewing on formatting, not content.  You only need ONE of them
+to approve in order to merge your PR**
+
+**If you are making simple corrections, reviewers may add comments to your PR without approving or requesting changes.  
+This is to avoid additional request/review cycles for simple changes.  
+You still need to address these changes before your PR is ready to merge**
+
+**Please add at least one content reviewer. If you don't add an
+additional reviewer with knowledge about the area you are writing about,
+one of the codeowners may add one**
+
+**If this is in response to a posted GitHub issue, please add "Fixes <issue #>"
+below so that it's referenced (i.e. "Fixes #122")**


### PR DESCRIPTION
Individual PR templates are not available to the GitHub UI, so this file
establishes a template that PR submitters will see.