### PR TITLE
[fix]Add redirect for new tutorial filename

### DIFF
--- a/page-index/page-index.js
+++ b/page-index/page-index.js
@@ -550,7 +550,11 @@ const pageIndex = [
                         href: "#in-depth-weather"
                     }
                 ]
-            }
+            }, {
+                type: HIDDEN_REDIRECT,
+                href: "tutorial-hello-nyc",
+                to: "/tutorials/tutorial-hello-timescale"
+            },
         ]
     }, {
         Title: "API reference",


### PR DESCRIPTION
This handles all links to the old tutorial by redirecting to the new version of the Hello tutorial