### PR TITLE
Remove getting-started/exploring-enterprise

### DIFF
--- a/getting-started/exploring-enterprise.md
+++ b/getting-started/exploring-enterprise.md
@@ -56,7 +56,7 @@ You'll be able to use the above command to check your license type and license e
 
 Continue exploring our enterprise features in our API docs.
 
-
+ 
 [products]: https://www.timescale.com/products
 [license]: https://www.timescale.com/enterprise-signup
 [contact-sales]: https://www.timescale.com/contact


### PR DESCRIPTION
This section is no longer relevant with our current cloud model. I believe it can be removed altogether to avoid potential confusion.
