### PR TITLE
Update interface for drop_chunks and friends

### DIFF
--- a/api.md
+++ b/api.md
@@ -1010,48 +1010,47 @@ SELECT distributed_exec($$CREATE USER davide WITH PASSWORD 'jw8s0F4'$$, node_lis
 
 ## drop_chunks() [](drop_chunks)
 
-Removes data chunks whose time range falls completely before (or after) a
-specified time, operating either across all hypertables or for a specific one.
-Shows a list of the chunks that were dropped, in the same style as the
-`show_chunks` [function][show chunks].
+Removes data chunks whose time range falls completely before (or
+after) a specified time.  Shows a list of the chunks that were
+dropped, in the same style as the `show_chunks` [function][show
+chunks].
 
-Chunks are defined by a certain start and end time.  If `older_than` is
-specified, a chunk is dropped if its end time is older than the specified
-timestamp. Alternatively, if `newer_than` is specified, a chunk is dropped if
-its start time is newer than the specified timestamp.  Note that, because
-chunks are removed if and only if their time range falls fully before (or
-after) the specified timestamp, the remaining data may still contain timestamps
-that are before (or after) the specified one.
+Chunks are constrained by a start and end time and the start time is
+always before the end time.  A chunk is dropped if its end time is
+older than the `older_than` timestamp or, if `newer_than` is given,
+its start time is newer than the `newer_than` timestamp.
+
+Note that, because chunks are removed if and only if their time range
+falls fully before (or after) the specified timestamp, the remaining
+data may still contain timestamps that are before (or after) the
+specified one.
 
 #### Required Arguments [](drop_chunks-required-arguments)
 
-Function requires at least one of the following arguments. These arguments have
-the same semantics as the `show_chunks` [function][show chunks].
-
 |Name|Description|
 |---|---|
+| `hypertable_or_cagg` | Hypertable or continuous aggregate from which to drop chunks.
 | `older_than` | Specification of cut-off point where any full chunks older than this timestamp should be removed. |
-| `newer_than` | Specification of cut-off point where any full chunks newer than this timestamp should be removed. |
 
 #### Optional Arguments [](drop_chunks-optional-arguments)
 
 |Name|Description|
 |---|---|
-| `table_name` | Hypertable name from which to drop chunks. If not supplied, all hypertables are affected.
-| `schema_name` | Schema name of the hypertable from which to drop chunks. Defaults to `public`.
-| `cascade` | Boolean on whether to `CASCADE` the drop on chunks, therefore removing dependent objects on chunks to be removed. Defaults to `FALSE`.
+| `newer_than` | Specification of cut-off point where any full chunks newer than this timestamp should be removed. |
+| `verbose` | (BOOLEAN) Setting to true will display messages about the progress of the reorder command. Defaults to false.|
 | `cascade_to_materializations` | Set to `TRUE` to delete chunk data in associated continuous aggregates. Defaults to `NULL`. `FALSE` is not yet supported.
 
 The `older_than` and `newer_than` parameters can be specified in two ways:
 
 - **interval type:** The cut-off point is computed as `now() -
-    older_than` and similarly `now() - newer_than`.  An error will be returned if an INTERVAL is supplied
-    and the time column is not one of a TIMESTAMP, TIMESTAMPTZ, or
-    DATE.
+    older_than` and similarly `now() - newer_than`.  An error will be
+    returned if an INTERVAL is supplied and the time column is not one
+    of a `TIMESTAMP`, `TIMESTAMPTZ`, or `DATE`.
 
 - **timestamp, date, or integer type:** The cut-off point is
-    explicitly given as a TIMESTAMP / TIMESTAMPTZ / DATE or as a
-    SMALLINT / INT / BIGINT. The choice of timestamp or integer must follow the type of the hypertable's time column.
+    explicitly given as a `TIMESTAMP` / `TIMESTAMPTZ` / `DATE` or as a
+    `SMALLINT` / `INT` / `BIGINT`. The choice of timestamp or integer
+    must follow the type of the hypertable's time column.
 
 
 >:WARNING: When using just an interval type, the function assumes that
@@ -1068,9 +1067,9 @@ intersection between two ranges will result in an error.
 
 #### Sample Usage [](drop_chunks-examples)
 
-Drop all chunks older than 3 months ago:
+Drop all chunks from hypertable `conditions` older than 3 months:
 ```sql
-SELECT drop_chunks(interval '3 months');
+SELECT drop_chunks('conditions', INTERVAL '3 months');
 ```
 
 Example output:
@@ -1086,44 +1085,34 @@ Example output:
 (5 rows)
 ```
 
-Drop all chunks more than 3 months in the future. This is useful for correcting data ingested with incorrect clocks:
-```sql
-SELECT drop_chunks(newer_than => now() + interval '3 months');
-```
+Drop all chunks more than 3 months in the future from hypertable
+`conditions`. This is useful for correcting data ingested with
+incorrect clocks:
 
-Drop all chunks from hypertable `conditions` older than 3 months:
 ```sql
-SELECT drop_chunks(interval '3 months', 'conditions');
+SELECT drop_chunks('conditions', newer_than => now() + interval '3 months');
 ```
 
 Drop all chunks from hypertable `conditions` before 2017:
 ```sql
-SELECT drop_chunks('2017-01-01'::date, 'conditions');
+SELECT drop_chunks('conditions', '2017-01-01'::date);
 ```
 
-Drop all chunks from hypertable `conditions` before 2017, where time column is given in milliseconds from the UNIX epoch:
-```sql
-SELECT drop_chunks(1483228800000, 'conditions');
-```
+Drop all chunks from hypertable `conditions` before 2017, where time
+column is given in milliseconds from the UNIX epoch:
 
-Drop all chunks from hypertable `conditions` older than 3 months, including dependent objects (e.g., views):
 ```sql
-SELECT drop_chunks(interval '3 months', 'conditions', cascade => TRUE);
-```
-
-Drop all chunks newer than 3 months ago:
-```sql
-SELECT drop_chunks(newer_than => interval '3 months');
+SELECT drop_chunks('conditions', 1483228800000);
 ```
 
 Drop all chunks older than 3 months ago and newer than 4 months ago:
 ```sql
-SELECT drop_chunks(older_than => interval '3 months', newer_than => interval '4 months', table_name => 'conditions')
+SELECT drop_chunks('conditions', older_than => interval '3 months', newer_than => interval '4 months')
 ```
 
 Drop all chunks older than 3 months, and delete this data from any continuous aggregates based on it:
 ```sql
-SELECT drop_chunks(interval '3 months', 'conditions', cascade_to_materializations => true);
+SELECT drop_chunks('conditions', interval '3 months', cascade_to_materializations => true);
 ```
 
 ---
@@ -1634,7 +1623,6 @@ one drop_chunks policy may exist per hypertable.
 
 |Name|Description|
 |---|---|
-| `cascade` | (BOOLEAN) Set to true to drop objects dependent upon chunks being dropped. Defaults to false.|
 | `if_not_exists` | (BOOLEAN) Set to true to avoid throwing an error if the drop_chunks_policy already exists. A notice is issued instead. Defaults to false. |
 | `cascade_to_materializations` | (BOOLEAN) Set to `TRUE` to delete chunk data in associated continuous aggregates. Defaults to `NULL`. `FALSE` is not yet supported. |
 
@@ -2535,7 +2523,6 @@ about drop_chunks policies).
 |---|---|
 | `hypertable` | (REGCLASS) The name of the hypertable on which the policy is applied |
 | `older_than` | (INTERVAL) Chunks fully older than this amount of time will be dropped when the policy is run |
-| `cascade` | (BOOLEAN) Whether the policy will be run with the cascade option turned on, which will cause dependent objects to be dropped as well as chunks. |
 | `job_id` | (INTEGER) The id of the background job set up to implement the drop_chunks policy|
 | `schedule_interval` | (INTERVAL)  The interval at which the job runs |
 | `max_runtime` | (INTERVAL) The maximum amount of time the job will be allowed to run by the background worker scheduler before it is stopped |
@@ -2548,9 +2535,9 @@ Get information about drop_chunks policies.
 ```sql
 SELECT * FROM timescaledb_information.drop_chunks_policies;
 
-       hypertable       | older_than | cascade | job_id | schedule_interval | max_runtime | max_retries | retry_period
-------------------------+------------+---------+--------+-------------------+-------------+-------------+--------------
-       conditions       | @ 4 mons   | t       |   1001 | @ 1 sec           | @ 5 mins    |          -1 | @ 12 hours
+       hypertable       | older_than | job_id | schedule_interval | max_runtime | max_retries | retry_period
+------------------------+------------+--------+-------------------+-------------+-------------+--------------
+       conditions       | @ 4 mons   |   1001 | @ 1 sec           | @ 5 mins    |          -1 | @ 12 hours
 (1 row)
 ```
 

--- a/introduction/timescaledb-vs-postgres.md
+++ b/introduction/timescaledb-vs-postgres.md
@@ -219,7 +219,7 @@ TimescaleDB allows efficient deletion of old data at the **chunk** level,
 rather than at the row level, via its `drop_chunks` functionality.
 
 ```sql
-SELECT drop_chunks(interval '7 days', 'conditions');
+SELECT drop_chunks('conditions', INTERVAL '7 days');
 ```
 
 This will delete all chunks (files) from the hypertable 'conditions'

--- a/using-timescaledb/data-retention.md
+++ b/using-timescaledb/data-retention.md
@@ -4,7 +4,7 @@ TimescaleDB allows efficient deletion of old data at the chunk level
 using the `drop_chunks` function.
 
 ```sql
-SELECT drop_chunks(interval '24 hours', 'conditions');
+SELECT drop_chunks('conditions', INTERVAL '24 hours');
 ```
 
 This will drop all chunks from the hypertable 'conditions' that _only_ include
@@ -59,7 +59,7 @@ like `crontab` or `systemd`, to schedule such commands.
 The following cron job will drop chunks every day at 3am:
 
 ```bash
-0 3 * * * /usr/bin/psql -h localhost -p 5432 -U postgres -d postgres -c "SELECT drop_chunks(interval '24 hours', 'conditions');" >/dev/null 2>&1
+0 3 * * * /usr/bin/psql -h localhost -p 5432 -U postgres -d postgres -c "SELECT drop_chunks('conditions', INTERVAL '24 hours');" >/dev/null 2>&1
 ```
 
 The above cron job can easily be installed by running `crontab -e`.
@@ -79,7 +79,7 @@ Description=Drop chunks from the 'conditions' table
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/psql -h localhost -p 5432 -U postgres -d postgres -c "SELECT drop_chunks(interval '24 hours', 'conditions');"
+ExecStart=/usr/bin/psql -h localhost -p 5432 -U postgres -d postgres -c "SELECT drop_chunks('conditions', INTERVAL '24 hours');"
 ```
 
 Then create a timer to run this unit, e.g., `/etc/systemd/system/retention.timer`:


### PR DESCRIPTION
The `cascade` option was removed from `drop_chunks` and
`add_drop_chunks_policy` and hence also disappeared from
`drop_chunks_policies` view.

In addition, `drop_chunks` now take a `REGCLASS` identifier as first
argument, so changed the signature and usage of the function.