### PR TITLE
Support compression on all PG versions

### DIFF
--- a/api.md
+++ b/api.md
@@ -976,14 +976,12 @@ policy](#add_compress_chunks_policy) for when to compress chunks.
 Advanced usage of compression alows users to [compress chunks
 manually](#compress_chunk), instead of automatically as they age.
 
->:WARNING: Compression is not available when using TimescaleDB on 
-PostgreSQL 9.6.
+#### Restrictions
 
- #### Restrictions
- Version 1.5 does not support altering or inserting data into compressed
- chunks. The data can be queried without any modifications, however if you
- need to backfill or update data in a compressed chunk you will need to
- decompress the chunk(s) first.
+Version 1.5 does not support altering or inserting data into compressed
+chunks. The data can be queried without any modifications, however if you
+need to backfill or update data in a compressed chunk you will need to
+decompress the chunk(s) first.
 
 
 #### Associated commands

--- a/using-timescaledb/compression.md
+++ b/using-timescaledb/compression.md
@@ -1,8 +1,5 @@
 # Compression
 
->:WARNING: Compression is not available when using TimescaleDB on 
-PostgreSQL 9.6.
-
 As of version 1.5, TimescaleDB supports the ability to natively compress data. This
 functionality does not require the use of any specific file system or external software,
 and as you will see, it is simple to set up and configure by the user.


### PR DESCRIPTION
2.0 release removes support for PostgreSQL 9.6 and 10, thus the 
compression is always supported and the warnings are not needed.
