### PR TITLE
Update documentation regarding pg_upgrade

### DIFF
--- a/api.md
+++ b/api.md
@@ -2775,6 +2775,9 @@ Specifically this sets the `timescaledb.restoring` GUC to `on` and stops any
 background workers which may have been performing tasks until the [`timescaledb_post_restore`](#timescaledb_post_restore)
 fuction is run following the restore. See [backup/restore docs][backup-restore] for more information.
 
+>:WARNING: Using this function when doing an upgrade could cause
+>issues in TimescaleDB versions before 1.7.1.
+
 >:WARNING: After running `SELECT timescaledb_pre_restore()` you must run the
   [`timescaledb_post_restore`](#timescaledb_post_restore) function before using the database normally.
 
@@ -2788,7 +2791,7 @@ SELECT timescaledb_pre_restore();
 
 ## timescaledb_post_restore() [](timescaledb_post_restore)
 Perform the proper operations after restoring the database has completed.
-Specifically this sets the `timescaledb.restoring` GUC to `off` and restarts any
+Specifically this resets the `timescaledb.restoring` GUC and restarts any
 background workers. See [backup/restore docs][backup-restore] for more information.
 
 #### Sample Usage  [](timescaledb_post_restore-examples)

--- a/using-timescaledb/update-db.md
+++ b/using-timescaledb/update-db.md
@@ -7,7 +7,7 @@ automated migration scripts that convert any internal state if necessary.
 
 >:TIP: If you are looking to upgrade the version of the **PostgreSQL instance** (e.g. from 11 to 12) rather than the version of the TimescaleDB extension, you have two choices. Either use [`pg_upgrade`][pg_upgrade] with the command:
 > ```
-> pg_upgrade -b oldbindir -B newbindir -d olddatadir -D newdatadir -O "-c timescaledb.restoring='on'"
+> pg_upgrade -b oldbindir -B newbindir -d olddatadir -D newdatadir"
 > ```
 > or [backup][] and then restore into a new version of the instance.
 


### PR DESCRIPTION
The variable `timescaledb.restoring` does not need to be set when
performing a `pg_upgrade` so that was removed from the instructions.

In addition, the `timescaledb_post_restore` function will now *reset*
the `timescaledb.restoring` flag rather than setting it to `off`.
Having `timescaledb.restoring` set to `off` on a database can cause
issues when upgrading PostgreSQL for older versions of TimescaleDB.