### PR TITLE
Remove version of current compression restriction

### DIFF
--- a/api.md
+++ b/api.md
@@ -978,7 +978,7 @@ manually](#compress_chunk), instead of automatically as they age.
 
 #### Restrictions
 
-Version 1.5 does not support altering or inserting data into compressed
+The current version does not support altering or inserting data into compressed
 chunks. The data can be queried without any modifications, however if you
 need to backfill or update data in a compressed chunk you will need to
 decompress the chunk(s) first.


### PR DESCRIPTION
The documentation is versioning per TimescaleDB release. Thus it is
clear for which versions the restrictions are applicable and there is
no need to mention specific version in the text.
