### PR TITLE
Remove CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,0 @@
-# This file is to set repo owners
-* @solugebefola @svenklemm @mfreed


### PR DESCRIPTION
Would like to convert PR process to not have explicit CODEOWNERS. Puts too much
friction in too few maintainers in a way that is not necessary to maintain
high-quality docs.
