### PR TITLE
Link mulitnode bootstrap description when related

### DIFF
--- a/api.md
+++ b/api.md
@@ -266,6 +266,8 @@ data node by:
 4. Setting metadata to make the data node part of the distributed
    database.
 
+See [boostrapping description][multinode-bootstrap] for details.
+
 #### Errors
 
 An error will be given if:
@@ -3363,3 +3365,4 @@ and then inspect `dump_file.txt` before sending it together with a bug report or
 [telemetry]: /using-timescaledb/telemetry
 [caveats]: /using-timescaledb/continuous-aggregates
 [backup-restore]: /using-timescaledb/backup#pg_dump-pg_restore
+[multinode-bootstrap]: /multinode/bootstrapping

--- a/getting-started/scaling-out.md
+++ b/getting-started/scaling-out.md
@@ -40,7 +40,8 @@ Note that:
   that will host a data node. The data node's database will be created
   when executing the [`add_data_node`][add_data_node] command on the
   access node and should _not_ exist prior to adding the data
-  node.
+  node. The process of bootstrapping data node is described in details 
+  [here][multinode-bootstrap].
 
 * The instance need to have a compatible version of the TimescaleDB
   extension available on the data node: typically the same version of
@@ -198,3 +199,4 @@ node.
 [data-node-authentication]: /getting-started/setup/data-node-authentication
 [max_prepared_transactions]: https://www.postgresql.org/docs/current/runtime-config-resource.html#GUC-MAX-PREPARED-TRANSACTIONS
 [distributed-hypertable-limitations]: /using-timescaledb/limitations#distributed-hypertable-limitations
+[multinode-bootstrap]: /multinode/bootstrapping

--- a/page-index/page-index.js
+++ b/page-index/page-index.js
@@ -448,18 +448,6 @@ const pageIndex = [
             }
         ]
     }, {
-	Title: "Distributed Hypertable",
-        type: REDIRECT,
-        href: "multinode",
-        to: "/multinode/bootstrapping",
-        children: [
-            {
-                Title: "Data Node Bootstrapping",
-                type: PAGE,
-                href: "bootstrapping",
-            }
-        ]
-    }, {
         Title: "Tutorials",
         type: PAGE,
         href: "tutorials",


### PR DESCRIPTION
This PR repeats #431, which was lost during rebase.

The detailed description of bootstrapping a data node is an advanced
topic. Having the multinode chapter with only this advanced topic can
be confusing to users. Thus the separate multinode chapter is removed
until there is enough content for the separate chapter. The
bootstrapping is instead linked from the sections, which describe
add_data_node functionality.

Fixes #419
