### PR TITLE
Fix typo in tutorial link

### DIFF
--- a/tutorials.md
+++ b/tutorials.md
@@ -74,7 +74,7 @@ and pick up some valuable `psql` tips and tricks along the way.
 [prometheus-tsc-endpoint]: /tutorials/tutorial-setting-up-timescale-cloud-endpoint-for-prometheus
 [prometheus-grafana]: /tutorials/tutorial-use-timescale-prometheus-grafana
 [monitor-django-prometheus]: /tutorials/tutorial-howto-monitor-django-prometheus
-[tutorial-grafana-dashboards]: /tutorials/tutorial-grafana-dashboard
+[tutorial-grafana-dashboards]: /tutorials/tutorial-grafana-dashboards
 [tutorial-grafana-geospatial]: /tutorials/tutorial-grafana-geospatial
 [tutorial-grafana-variables]: /tutorials/tutorial-grafana-variables
 [tutorial-grafana-missing-data]: /tutorials/tutorial-howto-visualize-missing-data-grafana


### PR DESCRIPTION
Current link goes to a 404 page, this PR links it to the correct page again