### PR TITLE
Remove data node auth from single-node nav

### DIFF
--- a/getting-started/setup-multi-node.md
+++ b/getting-started/setup-multi-node.md
@@ -64,7 +64,7 @@ Note that:
 
 When creating the data node, you should:
 
-* Run `add_data_node` as a superuser that can authenticate with the
+* Run [`add_data_node`][add_data_node] as a superuser that can authenticate with the
   data node instance. This can be done by setting up either password
   or certificate [authentication][data-node-auth].
 

--- a/introduction/architecture.md
+++ b/introduction/architecture.md
@@ -103,7 +103,7 @@ compression, read our [compression blog post].
 ## Single Node vs. Multi-Node [](single-node-vs-clustering)
 
 TimescaleDB performs extensive partitioning both
-on **single-node** deployments as well as **clustered** deployments.
+on **single-node** deployments as well as **multi-node** deployments.
 While
 partitioning is traditionally only used for scaling out across multiple
 machines, it also allows us to scale up to high write rates (and improved

--- a/page-index/page-index.js
+++ b/page-index/page-index.js
@@ -182,10 +182,6 @@ const pageIndex = [
                         type: HIDDEN_REDIRECT,
                         href: "migrate-from-postgresql",
                         to: "/getting-started/migrating-data"
-                    }, {
-                  	Title: "Data Node Authentication",
-                  	type: PAGE,
-                        href: "data-node-authentication",
                     }
                 ]
             }, {


### PR DESCRIPTION
- Remove (broken) link to data node auth from child of setting
  up TimescaleDB. It's now part of separate setting up multi-node
  TimescaleDB page.

- Few other nits.
