### PR TITLE
Update add/remove_drop_chunk_policy names

### DIFF
--- a/api.md
+++ b/api.md
@@ -2,11 +2,11 @@
 
 >:TOPLIST:
 > ### Command List (A-Z)
+> - [add_compression_policy](#add_compression_policy)
 > - [add_dimension](#add_dimension)
 > - [add_data_node](#add_data_node)
-> - [add_drop_chunks_policy](#add_drop_chunks_policy)
 > - [add_reorder_policy](#add_reorder_policy)
-> -	[add_compress_chunks_policy](#add_compress_chunks_policy)
+> - [add_retention_policy](#add_retention_policy)
 > - [allow_new_chunks](#allow_new_chunks)
 > - [alter_job_schedule](#alter_job_schedule)
 > - [alter table (compression)](#compression_alter-table)
@@ -42,9 +42,9 @@
 > - [locf](#locf)
 > - [move_chunk](#move_chunk)
 > - [refresh materialized view (continuous aggregate)](#continuous_aggregate-refresh_view)
-> -	[remove_compress_chunks_policy](#remove_compress_chunks_policy)
-> - [remove_drop_chunks_policy](#remove_drop_chunks_policy)
+> - [remove_compression_policy](#remove_compression_policy)
 > - [remove_reorder_policy](#remove_reorder_policy)
+> - [remove_retention_policy](#remove_retention_policy)
 > - [reorder_chunk](#reorder_chunk)
 > - [set_chunk_time_interval](#set_chunk_time_interval)
 > - [set_integer_now_func](#set_integer_now_func)
@@ -1477,7 +1477,7 @@ for the first time.
 
 Setting up compression on TimescaleDB requires users to first [configure the
 hypertable for compression](#compression_alter-table) and then [set up a
-policy](#add_compress_chunks_policy) for when to compress chunks.
+policy](#add_compression_policy) for when to compress chunks.
 
 Advanced usage of compression alows users to [compress chunks
 manually](#compress_chunk), instead of automatically as they age.
@@ -1492,8 +1492,8 @@ decompress the chunk(s) first.
 
 #### Associated commands
 *	[ALTER TABLE](#compression_alter-table)
-*	[add_compress_chunks_policy](#add_compress_chunks_policy)
-*	[remove_compress_chunks_policy](#remove_compress_chunks_policy)
+*	[add_compression_policy](#add_compression_policy)
+*	[remove_compression_policy](#remove_compression_policy)
 *	[compress_chunk](#compress_chunk)
 *	[decompress_chunk](#decompress_chunk)
 
@@ -1533,11 +1533,11 @@ Configure a hypertable that ingests device data to use compression.
 ALTER TABLE metrics SET (timescaledb.compress, timescaledb.compress_orderby = 'time DESC', timescaledb.compress_segmentby = 'device_id');
 ```
 
-## add_compress_chunks_policy() :community_function: [](add_compress_chunks_policy)
+## add_compression_policy() :community_function: [](add_compression_policy)
 Allows you to set a policy by which the system will compress a chunk
 automatically in the background after it reaches a given age.
 
-#### Required Arguments [](add_compress_chunks_policy-required-arguments)
+#### Required Arguments [](add_compression_policy-required-arguments)
 
 |Name|Description|
 |---|---|
@@ -1549,39 +1549,39 @@ The `time_interval` parameter should be specifified differently depending on the
 - For hypertables with integer-based timestamps: the time interval should be an integer type (this requires
 the [integer_now_func](#set_integer_now_func) to be set).
 
-#### Sample Usage [](add_compress_chunks_policy-sample-usage)
+#### Sample Usage [](add_compression_policy-sample-usage)
 Add a policy to compress chunks older than 60 days on the 'cpu' hypertable.
 
 ``` sql
-SELECT add_compress_chunks_policy('cpu', INTERVAL '60d');
+SELECT add_compression_policy('cpu', INTERVAL '60d');
 ```
 
 Add a compress chunks policy to a hypertable with an integer-based time column:
 
 ``` sql
-SELECT add_compress_chunks_policy('table_with_bigint_time', BIGINT '600000');
+SELECT add_compression_policy('table_with_bigint_time', BIGINT '600000');
 ```
 
-## remove_compress_chunks_policy() :community_function: [](remove_compress_chunks_policy)
+## remove_compression_policy() :community_function: [](remove_compression_policy)
 If you need to remove the compression policy. To re-start policy basd compression again you will need to re-add the policy.
 
-#### Required Arguments [](remove_compress_chunks_policy-required-arguments)
+#### Required Arguments [](remove_compression_policy-required-arguments)
 
 |Name|Description|
 |---|---|
 | `table_name` | (REGCLASS) Name of the hypertable the policy should be removed from.|
 
-#### Sample Usage [](remove_compress_chunks_policy-sample-usage)
+#### Sample Usage [](remove_compression_policy-sample-usage)
 Remove the compression policy from the 'cpu' table:
 ``` sql
-SELECT remove_compress_chunks_policy('cpu');
+SELECT remove_compression_policy('cpu');
 ```
 
 ## compress_chunk() :community_function: [](compress_chunk)
 
 The compress_chunk function is used to compress a specific chunk. This is
 most often used instead of the
-[add_compress_chunks_policy](#add_compress_chunks_policy) function, when a user
+[add_compression_policy](#add_compression_policy) function, when a user
 wants more control over the scheduling of compression. For most users, we
 suggest using the policy framework instead.
 
@@ -1862,21 +1862,21 @@ are meant to implement data retention or perform tasks that will improve query
 performance on older chunks. Each policy is assigned a scheduled job
 which will be run in the background to enforce it.
 
-## add_drop_chunks_policy() :community_function: [](add_drop_chunks_policy)
+## add_retention_policy() :community_function: [](add_retention_policy)
 
 Create a policy to drop chunks older than a given interval of a particular
 hypertable or continuous aggregate on a schedule in the background. (See [drop_chunks](#drop_chunks)).
 This implements a data retention policy and will remove data on a schedule. Only
 one drop-chunks policy may exist per hypertable.
 
-#### Required Arguments [](add_drop_chunks_policy-required-arguments)
+#### Required Arguments [](add_retention_policy-required-arguments)
 
 |Name|Description|
 |---|---|
 | `table_name` | (REGCLASS) Name of the hypertable or continuous aggregate to create the policy for. |
-| `older_than` | (INTERVAL) Chunks fully older than this interval when the policy is run will be dropped|
+| `retention_window` | (INTERVAL) Chunks fully older than this interval when the policy is run will be dropped|
 
-#### Optional Arguments [](add_drop_chunks_policy-optional-arguments)
+#### Optional Arguments [](add_retention_policy-optional-arguments)
 
 |Name|Description|
 |---|---|
@@ -1885,45 +1885,45 @@ one drop-chunks policy may exist per hypertable.
 
 >:WARNING: If a drop chunks policy is setup which does not set `cascade_to_materializations` to either `TRUE` or `FALSE` on a hypertable that has a continuous aggregate, the policy will not drop any chunks.
 
-#### Returns [](add_drop_chunks_policy-returns)
+#### Returns [](add_retention_policy-returns)
 
 |Column|Description|
 |---|---|
 |`job_id`| (INTEGER)  TimescaleDB background job id created to implement this policy|
 
 
-#### Sample Usage [](add_drop_chunks_policy-examples)
+#### Sample Usage [](add_retention_policy-examples)
 
 
 ```sql
-SELECT add_drop_chunks_policy('conditions', INTERVAL '6 months');
+SELECT add_retention_policy('conditions', INTERVAL '6 months');
 ```
 
 creates a data retention policy to discard chunks greater than 6 months old.
 
 ---
-## remove_drop_chunks_policy() :community_function: [](remove_drop_chunks_policy)
+## remove_retention_policy() :community_function: [](remove_retention_policy)
 Remove a policy to drop chunks of a particular hypertable.
 
-#### Required Arguments [](remove_drop_chunks_policy-required-arguments)
+#### Required Arguments [](remove_retention_policy-required-arguments)
 
 |Name|Description|
 |---|---|
 | `table_name` | (REGCLASS) Name of the hypertable or continuous aggregate to create the policy for. |
 
 
-#### Optional Arguments [](remove_drop_chunks_policy-optional-arguments)
+#### Optional Arguments [](remove_retention_policy-optional-arguments)
 
 |Name|Description|
 |---|---|
 | `if_exists` | (BOOLEAN)  Set to true to avoid throwing an error if the policy does not exist. Defaults to false.|
 
 
-#### Sample Usage [](remove_drop_chunks_policy-examples)
+#### Sample Usage [](remove_retention_policy-examples)
 
 
 ```sql
-SELECT remove_drop_chunks_policy('conditions');
+SELECT remove_retention_policy('conditions');
 ```
 
 removes the existing data retention policy for the `conditions` table.
@@ -2891,7 +2891,7 @@ total_crashes          | 0
 ---
 ## timescaledb_information.drop_chunks_policies [](timescaledb_information-drop_chunks_policies)
 Shows information about drop_chunks policies that have been created by the user.
-(See [add_drop_chunks_policy](#add_drop_chunks_policy) for more information
+(See [add_retention_policy](#add_retention_policy) for more information
 about drop_chunks policies).
 
 

--- a/tutorials/tutorial-use-timescale-prometheus-grafana.md
+++ b/tutorials/tutorial-use-timescale-prometheus-grafana.md
@@ -58,7 +58,7 @@ ALTER TABLE metrics_values SET (
  timescaledb.compress_segmentby = 'labels_id'
 );
 
-SELECT add_compress_chunks_policy('metrics_values', INTERVAL '6 hours');
+SELECT add_compression_policy('metrics_values', INTERVAL '6 hours');
 ```
 
 You can change the interval from `6 hours`, to `1 day` or `2 days` and so on, depending 
@@ -99,7 +99,7 @@ can enable that, using the scenario of keeping data around for 2 days:
 ```sql
 --Adding a data retention policy to drop chunks that only consist of data older than 2 days old
 -- available on Timescale Cloud and in Timescale Community v 1.7+
-SELECT add_drop_chunks_policy('metrics_values', INTERVAL '2 days', cascade_to_materializations=>FALSE);
+SELECT add_retention_policy('metrics_values', INTERVAL '2 days', cascade_to_materializations=>FALSE);
 ```
 
 To check if the policy was created successfully and for information about the policy, run:

--- a/using-timescaledb/compression.md
+++ b/using-timescaledb/compression.md
@@ -33,7 +33,7 @@ ALTER TABLE measurements SET (
   timescaledb.compress_segmentby = 'device_id'
 );
 
-SELECT add_compress_chunks_policy('measurements', INTERVAL '7 days');
+SELECT add_compression_policy('measurements', INTERVAL '7 days');
 ```
 
 Thats it! These two commands configure compression and

--- a/using-timescaledb/continuous-aggregates.md
+++ b/using-timescaledb/continuous-aggregates.md
@@ -338,8 +338,8 @@ process invalidations on data regions where the raw data has been
 dropped.
 
 
-The same argument must also be supplied to the [`add_drop_chunks_policy`
-function][api-add-drop-chunks] when creating a data retention policy for a
+The same argument must also be supplied to the [`add_retention_policy`
+function][api-add-retention] when creating a data retention policy for a
 hypertable with a continuous aggregate.  
 
 ---
@@ -570,7 +570,7 @@ implement a number of these aggregates.
 [api-drop-chunks]: /api#drop_chunks
 [api-set-chunk-interval]: /api#set_chunk_time_interval
 [api-set-integer-now-func]: /api#set_integer_now_func
-[api-add-drop-chunks]: /api#add_drop_chunks_policy
+[api-add-retention]: /api#add_retention_policy
 [timescale-github]: https://github.com/timescale/timescaledb
 [support-slack]: https://slack-login.timescale.com
 [postgres-ordered-set]: https://www.postgresql.org/docs/current/functions-aggregate.html#FUNCTIONS-ORDEREDSET-TABLE

--- a/using-timescaledb/data-retention.md
+++ b/using-timescaledb/data-retention.md
@@ -137,12 +137,12 @@ according to some defined schedule.
 To add such a policy on a hypertable, continually causing chunks older than 24
 hours to be deleted, simply execute the command:
 ```sql
-SELECT add_drop_chunks_policy('conditions', INTERVAL '24 hours');
+SELECT add_retention_policy('conditions', INTERVAL '24 hours');
 ```
 
 To subsequently remove the policy:
 ```sql
-SELECT remove_drop_chunks_policy('conditions');
+SELECT remove_retention_policy('conditions');
 ```
 
 The scheduler framework also allows one to view scheduled jobs:
@@ -150,7 +150,7 @@ The scheduler framework also allows one to view scheduled jobs:
 SELECT * FROM timescaledb_information.drop_chunks_policies;
 ```
 
-For more information, please see the [API documentation][add_drop_chunks_policy].
+For more information, please see the [API documentation][add_retention_policy].
 
 
 ### Using External Job Schedulers
@@ -213,6 +213,6 @@ and immediately start it.
 
 
 [drop_chunks]: /api#drop_chunks
-[add_drop_chunks_policy]: /api#add_drop_chunks_policy
+[add_retention_policy]: /api#add_retention_policy
 [unit]: https://www.freedesktop.org/software/systemd/man/systemd.unit.html
 [timer]: https://www.freedesktop.org/software/systemd/man/systemd.timer.html

--- a/using-timescaledb/move_chunk.md
+++ b/using-timescaledb/move_chunk.md
@@ -182,7 +182,7 @@ verbose=>TRUE);
 [api-continuous-aggregate-stats]: /api#timescaledb_information-continuous_aggregate_stats
 [api-drop-chunks]: /api#drop_chunks
 [api-set-chunk-interval]: /api#set_chunk_time_interval
-[api-add-drop-chunks]: /api#add_drop_chunks_policy
+[api-add-retention]: /api#add_retention_policy
 [timescale-github]: https://github.com/timescale/timescaledb
 [support-slack]: https://slack-login.timescale.com
 [postgres-ordered-set]: https://www.postgresql.org/docs/current/functions-aggregate.html#FUNCTIONS-ORDEREDSET-TABLE


### PR DESCRIPTION
We've modified the add_drop_chunks_policy and
remove_drop_chunk_policy commands to be add/remove_retention_policy
and have renamed the `older_than` parameter of the
add_retention_policy to be called `retention_window`.  This PR
updates the documentation with these changes.

This PR also renames the add/remove_compress_chunks_policy to
add/remove_compression_policy.