### PR TITLE
Label automation as community feature

### DIFF
--- a/api.md
+++ b/api.md
@@ -1849,7 +1849,7 @@ aggregate, such as views that are built on top of the continuous aggregate view.
 
 
 ---
-## Automation policies [](automation-policies)
+## Automation policies :community_function: [](automation-policies)
 
 TimescaleDB includes an automation framework for allowing background tasks to
 run inside the database, controllable by user-supplied policies. These tasks
@@ -1862,7 +1862,7 @@ are meant to implement data retention or perform tasks that will improve query
 performance on older chunks. Each policy is assigned a scheduled job
 which will be run in the background to enforce it.
 
-## add_drop_chunks_policy() [](add_drop_chunks_policy)
+## add_drop_chunks_policy() :community_function: [](add_drop_chunks_policy)
 
 Create a policy to drop chunks older than a given interval of a particular
 hypertable or continuous aggregate on a schedule in the background. (See [drop_chunks](#drop_chunks)).
@@ -1902,7 +1902,7 @@ SELECT add_drop_chunks_policy('conditions', INTERVAL '6 months');
 creates a data retention policy to discard chunks greater than 6 months old.
 
 ---
-## remove_drop_chunks_policy() [](remove_drop_chunks_policy)
+## remove_drop_chunks_policy() :community_function: [](remove_drop_chunks_policy)
 Remove a policy to drop chunks of a particular hypertable.
 
 #### Required Arguments [](remove_drop_chunks_policy-required-arguments)
@@ -1930,7 +1930,7 @@ removes the existing data retention policy for the `conditions` table.
 
 
 ---
-## add_reorder_policy() [](add_reorder_policy)
+## add_reorder_policy() :community_function: [](add_reorder_policy)
 Create a policy to reorder chunks on a given hypertable index in the
 background. (See [reorder_chunk](#reorder_chunk)). Only one reorder policy may
 exist per hypertable. Only chunks that are the 3rd from the most recent will be
@@ -1972,7 +1972,7 @@ SELECT add_reorder_policy('conditions', 'conditions_device_id_time_idx');
 creates a policy to reorder completed chunks by the existing `(device_id, time)` index. (See [reorder_chunk](#reorder_chunk)).
 
 ---
-## remove_reorder_policy() [](remove_reorder_policy)
+## remove_reorder_policy() :community_function: [](remove_reorder_policy)
 Remove a policy to reorder a particular hypertable.
 
 #### Required Arguments [](remove_reorder_policy-required-arguments)


### PR DESCRIPTION
Retention and reorder policies are community features and thus needs to be labeled accordantly.
