### PR TITLE
Update retention documentation for 2.0

### DIFF
--- a/api.md
+++ b/api.md
@@ -1967,7 +1967,6 @@ one retention policy may exist per hypertable.
 |---|---|
 | `if_not_exists` | (BOOLEAN) Set to true to avoid throwing an error if the drop_chunks_policy already exists. A notice is issued instead. Defaults to false. |
 
-
 #### Returns [](add_retention_policy-returns)
 
 |Column|Description|

--- a/using-timescaledb/continuous-aggregates.md
+++ b/using-timescaledb/continuous-aggregates.md
@@ -402,6 +402,24 @@ and information about the state and progress of the materialization background w
 These views can be quite useful for administering continuous aggregates and
 tuning other options noted below.
 
+### Dropping Data with Continuous Aggregates Enabled [](dropping-data)
+Note that if any still-refreshing (more recent than `start_offset`) part of the
+continuous aggregate is dropped via a [retention policy][api-add-retention] or
+direct [`drop_chunks`][api-drop-chunks] call, the aggregate will be updated to
+reflect the loss of data. For this reason, if it is desired to retain the continuous
+aggregate after dropping the underlying data, the `start_offset` of the aggregate
+policy must be set to a smaller interval than the `drop_after` parameter of a
+hypertable's retention policy. Similiarly, when calling `drop_chunks`, extra
+care should also be taken to ensure that any such chunks are not within the
+refresh window of a continuous aggregate that still needs the data.  More detail
+and examples of this can be seen in the the [data retention documentation][retention-aggregate].
+
+This is also a consideration when manually refreshing a continuous aggregate.
+Calling `refresh_continuous_aggregate` on a region containing dropped chunks will
+recalculate the aggregate without the dropped data. This can lead to undesirable
+results, such as replacing previous aggregate data with NULL values, given that the
+raw data has subsequently been dropped.
+
 #### Continuous Aggregates using Integer-Based Time [](create-integer)
 
 Usually, continuous aggregates are defined on a
@@ -610,3 +628,4 @@ SELECT min_time::timestamp FROM device_summary;
 [clock_timestamp]: http://www.postgresql.org/docs/12/functions-datetime.html#FUNCTIONS-DATETIME-CURRENT
 [add-continuous-aggregate-policy]: /api#add_continuous_aggregate_policy
 [refresh_continuous_aggregate]: /api#refresh_continuous_aggregate
+[retention-aggregate]: /using-timescaledb/data-retention#retention-with-aggregates


### PR DESCRIPTION
This change modifies several of the documentation pages to reflect
the api changes introduced in 2.0. Most significantly, removing the
cascade_to_materializations option from drop chunks and the
associated policy invalidated a large section of documentation we
had explaining it.  This has been replaced with warnings of
potential interactions between continuous aggregates and drop_chunks
and instructions for how to avoid these issues.

Additionally, there was a section on using external job schedulers
within the data-retention page. Given that the retention policy
framework should now be a preferable approach for almost all users,
this section was removed.

PR instructions

1. Describe your PR right below:



---
2. Add label for the earliest DB version your changes apply to -->>

3. If you are changing page names or in-page anchors, you must update the
`page-index.js` file

4. Please add at least one content reviewer. If you don't add an
additional reviewer with knowledge about the area you are writing about,
one of the codeowners may add one

5. If this is in response to a posted GitHub issue, please add "Fixes <issue #>"
below so that it's referenced (i.e. "Fixes #122")

5. If you are making simple corrections, reviewers may add comments to your
PR without officially requesting changes. This is to avoid additional
request/review cycles for simple changes. Make sure to address these
comments (i.e. with changes) before your PR is ready to merge

6. Feel free to delete these instructions in your PR message after everything
else is filled out
---
Additional notes:

The default reviewers (CODEOWNERS) are added to each PR.  They will
primarily be reviewing on formatting, not content.  You only need ONE of them
to approve in order to merge your PR
