### PR TITLE
Add timescaledb.license API section

### DIFF
--- a/api.md
+++ b/api.md
@@ -61,6 +61,7 @@
 > - [timescaledb_information.hypertables](#timescaledb_information-hypertables)
 > - [timescaledb_information.job_stats](#timescaledb_information-job_stats)
 > - [timescaledb_information.reorder_policies](#timescaledb_information-reorder_policies)
+> - [timescaledb.license](#timescaledb_license)
 > - [timescaledb_pre_restore](#timescaledb_pre_restore)
 > - [timescaledb_post_restore](#timescaledb_post_restore)
 
@@ -3434,6 +3435,30 @@ background workers. See [backup/restore docs][backup-restore] for more informati
 
 ```sql
 SELECT timescaledb_post_restore();
+```
+---
+
+## timescaledb.license [](timescaledb_license)
+
+View or set currently used TimescaleDB license.
+
+It is possible to limit access to features by license by changing the `timescaledb.license`
+settings parameter in the server configuration file or on the server command line. For instance,
+by setting `timescaledb.license` to `apache`, it is only possible to use TimescaleDB features
+that are implemented under the Apache 2 license. The default value is `timescale`, however, which
+allows access to all features.
+
+#### Sample Usage [](timescaledb_license-key-examples)
+
+View current license.
+
+```sql
+SHOW timescaledb.license;
+ timescaledb.license
+---------------------
+ timescale
+(1 row)
+
 ```
 ---
 


### PR DESCRIPTION
This PR brings back `timescaledb.license` guc description and updates it according to the recent changes