### PR TITLE
Add sample datasets size

### DIFF
--- a/tutorials/other-sample-datasets.md
+++ b/tutorials/other-sample-datasets.md
@@ -14,9 +14,9 @@ you are importing them to has already been [set up with the TimescaleDB extensio
 memory, network) collected from mobile devices. (Click on the name to
 download.)
 
-1. [:DOWNLOAD_LINK: `devices_small`][devices-small] - 1,000 devices recorded over 1,000 time intervals
-1. [:DOWNLOAD_LINK: `devices_med`][devices-medium] - 5,000 devices recorded over 2,000 time intervals
-1. [:DOWNLOAD_LINK: `devices_big`][devices-big] - 3,000 devices recorded over 10,000 time intervals
+1. [:DOWNLOAD_LINK: `devices_small`][devices-small] - 1,000 devices recorded over 1,000 time intervals - 39MB
+1. [:DOWNLOAD_LINK: `devices_med`][devices-medium] - 5,000 devices recorded over 2,000 time intervals - 390MB
+1. [:DOWNLOAD_LINK: `devices_big`][devices-big] - 3,000 devices recorded over 10,000 time intervals - 1.2GB
 
 For more details and example usage, see [In-depth: Device ops datasets](#in-depth-devices).
 
@@ -24,9 +24,9 @@ For more details and example usage, see [In-depth: Device ops datasets](#in-dept
 humidity data from a variety of locations. (Click on the name to
 download.)
 
-1. [:DOWNLOAD_LINK: `weather_small`][weather-small] - 1,000 locations over 1,000 two-minute intervals
-1. [:DOWNLOAD_LINK: `weather_med`][weather-medium] - 1,000 locations over 15,000 two-minute intervals
-1. [:DOWNLOAD_LINK: `weather_big`][weather-big] - 2,000 locations over 20,000 two-minute intervals
+1. [:DOWNLOAD_LINK: `weather_small`][weather-small] - 1,000 locations over 1,000 two-minute intervals - 8.1MB
+1. [:DOWNLOAD_LINK: `weather_med`][weather-medium] - 1,000 locations over 15,000 two-minute intervals - 115MB
+1. [:DOWNLOAD_LINK: `weather_big`][weather-big] - 2,000 locations over 20,000 two-minute intervals - 305MB
 
 For more details and example usage, see [In-depth: Weather datasets](#in-depth-weather).
 


### PR DESCRIPTION
While experimenting with timescaledb and the provided datasets users
might need to know the size of the files they are downloading. For
example they might be playing with it on an instance with fixed/limited
storage.

---
Additional notes:
```
du -sh *
1.2G    devices_big.tar.gz
390M    devices_med.tar.gz
39M     devices_small.tar.gz
305M    weather_big.tar.gz
115M    weather_med.tar.gz
8.1M    weather_small.tar.gz
```

I could be a good idea to provide a checksum file to allow users to validate the download
```
sha256sum *.tar.gz
d5f74262d790923dae75a1aab9bc471f8e5577b045302ac7289aaee1b49f75b0  devices_big.tar.gz
add7b754005b3a0d4d2daa8122d7e102c6f3f7989040affd7aa1fb657c666d7e  devices_med.tar.gz
98bacac42ac18cd1b4b4dedbdc3dcfa87ff2af4ee606ba6d577ebcff77065fff  devices_small.tar.gz
6504f98d039af1caba3479823604d75e4547d515325ebef83e04f6584682635a  weather_big.tar.gz
16f1eb14fad0e76aafadedf49fec418f7ae1b2760a9a65d1072404084c2c66f9  weather_med.tar.gz
ef2049883c837719130d5f3abe31705662c537cf96d5ccaf19e0a1303eaec6b3  weather_small.tar.gz
```