### PR TITLE
Clarify single hypertable in continuous aggregate

### DIFF
--- a/api.md
+++ b/api.md
@@ -1610,6 +1610,11 @@ GROUP BY <time_bucket( <const_value>, <partition_col_of_hypertable> ),
          [ optional grouping exprs>]
 [HAVING ...]
 ```
+Note that continuous aggregates have some limitations of what types of
+queries they can support, described in more length below.  For example,
+the `FROM` clause must provide only one hypertable, i.e., no joins, views or 
+subqueries ares upported, the `GROUP BY` clause must include a time bucket on 
+the hypertable's time column, and all aggregates must be parallelizable.
 
 #### Parameters
 |Name|Description|
@@ -1644,10 +1649,14 @@ GROUP BY <time_bucket( <const_value>, <partition_col_of_hypertable> ),
 - The view will be automatically refreshed (as outlined under
   [`refresh_continuous_aggregate`](#refresh_continuous_aggregate))
   unless `WITH NO DATA` is given (`WITH DATA` is the default).
-- `SELECT` query should be of the form specified in the syntax above.
+- The `SELECT` query should be of the form specified in the syntax above, which is discussed in
+  the following items.
+- Only a single hypertable can be specified in the `FROM` clause of the 
+  `SELECT` query. This means that including more hypertables, joins, tables, views, subqueries
+  is not supported.
 - The hypertable used in the `SELECT` may not have [row-level-security
   policies][postgres-rls] enabled.
--  `GROUP BY` clause must include a time_bucket expression. The
+-  The `GROUP BY` clause must include a time_bucket expression. The
    [`time_bucket`](#time_bucket) expression must use the time
    dimension column of the hypertable.
 - [`time_bucket_gapfill`](#time_bucket_gapfill) is not allowed in continuous


### PR DESCRIPTION
There is no explicit note in continuous aggregate that it can select only from one hypertable. This commit adds notes and clarifiesthis.
