### PR TITLE
Remove references to continuous_aggregate_stats from api.md

### DIFF
--- a/api.md
+++ b/api.md
@@ -2148,21 +2148,18 @@ SELECT alter_job(1000, schedule_interval => INTERVAL '2 days');
 Reschedules the job with id 1000 so that it runs every two days.
 
 ```sql
-SELECT alter_job(job_id, schedule_interval => INTERVAL '5 minutes')
-FROM timescaledb_information.continuous_aggregate_stats
-WHERE view_name = 'conditions_agg'::regclass;
+SELECT alter_job(job_id, scheduled => false)
+FROM timescaledb_information.jobs
+WHERE proc_name = 'policy_compression' AND hypertable_name = 'conditions'
 ```
-Reschedules the continuous aggregate job for the `conditions_agg` view so that it runs every five minutes.
+Disables scheduling of the compression policy on hypertable `conditions`.
 
 ```sql
 SELECT alter_job(1015, next_start => '2020-03-15 09:00:00.0+00');
 ```
 
 Reschedules continuous aggregate job `1015` so that the next execution of the
-job starts at the specified time (9:00:00 am on March 15, 2020).  This same
-query could have simultaneously changed the `schedule_interval` or queried the
-`timescaledb_information.continuous_aggregate_stats` informational view to
-extract the `job_id`, as shown above.
+job starts at the specified time (9:00:00 am on March 15, 2020).
 
 ---
 ## Analytics [](analytics)

--- a/using-timescaledb/continuous-aggregates.md
+++ b/using-timescaledb/continuous-aggregates.md
@@ -335,7 +335,7 @@ The various options used to create the continuous aggregate view, as well as its
 definition, can be found in the
 [`timescaledb_information.continuous_aggregates` view][api-continuous-aggregates-info],
 and information about the state and progress of the materialization background worker jobs can be found in the
-[`timescaledb_information.continuous_aggregate_stats` view][api-continuous-aggregate-stats].
+[`timescaledb_information.job_stats` view][api-job-stats].
 These views can be quite useful for administering continuous aggregates and
 tuning other options noted below.
 
@@ -554,7 +554,7 @@ SELECT min_time::timestamp FROM device_summary;
 [api-refresh-continuous-aggs]: /api#continuous_aggregate-refresh_view
 [api-alter-cagg]: /api#continuous_aggregate-alter_view
 [api-continuous-aggregates-info]: /api#timescaledb_information-continuous_aggregate
-[api-continuous-aggregate-stats]: /api#timescaledb_information-continuous_aggregate_stats
+[api-job-stats]: /api#timescaledb_information-job_stats
 [api-drop-chunks]: /api#drop_chunks
 [api-set-chunk-interval]: /api#set_chunk_time_interval
 [api-set-integer-now-func]: /api#set_integer_now_func

--- a/using-timescaledb/move_chunk.md
+++ b/using-timescaledb/move_chunk.md
@@ -179,7 +179,6 @@ verbose=>TRUE);
 [postgres-parallel-agg]:https://www.postgresql.org/docs/current/parallel-plans.html#PARALLEL-AGGREGATION
 [api-refresh-continuous-aggs]: /api#continuous_aggregate-refresh_view
 [api-continuous-aggregates-info]: /api#timescaledb_information-continuous_aggregate
-[api-continuous-aggregate-stats]: /api#timescaledb_information-continuous_aggregate_stats
 [api-drop-chunks]: /api#drop_chunks
 [api-set-chunk-interval]: /api#set_chunk_time_interval
 [api-add-retention]: /api#add_retention_policy


### PR DESCRIPTION
continuous_aggregate_stats view got removed so this patch adjusts
examples in api.md that reference it.
