### PR TITLE
Changes for TimescaleDB 2.0.0-rc2 launch

### DIFF
--- a/faq.md
+++ b/faq.md
@@ -372,6 +372,6 @@ See our [updating documentation][update]. [[Top]](#top)
 [contact]: https://www.timescale.com/contact
 [join_slack]: https://slack-login.timescale.com/
 [install]: /getting-started/installation
-[update]: /using-timescaledb/update-db
+[update]: /update-timescaledb
 [compression-docs]: /using-timescaledb/compression
 [compression-blog]: https://blog.timescale.com/blog/building-columnar-compression-in-a-row-oriented-database/

--- a/getting-started/installation-apt-debian.md
+++ b/getting-started/installation-apt-debian.md
@@ -1,6 +1,6 @@
 >:WARNING: These installation instructions will install the current Release Candidate
-for TimescaleDB 2.0, which includes the ability to setup [Multi-Node capabilities][multi-node-basic]. For
-more information, please [contact us][contact] or join the #multinode-beta channel in our 
+for TimescaleDB 2.0, which includes the ability to setup [multi-node capabilities][multi-node-basic]. For
+more information, please [contact us][contact] or join the #multinode channel in our 
 [community Slack][slack].
 
 ## apt Installation (Debian) [](installation-apt-debian)

--- a/getting-started/installation-apt-debian.md
+++ b/getting-started/installation-apt-debian.md
@@ -1,6 +1,6 @@
->:WARNING: Our scaling out capabilities are currently in BETA and
-are not available through this installation method. For more information,
-please [contact us][contact] or join the #multinode-beta channel in our 
+>:WARNING: These installation instructions will install the current Release Candidate
+for TimescaleDB 2.0, which includes the ability to setup [Multi-Node capabilities][multi-node-basic]. For
+more information, please [contact us][contact] or join the #multinode-beta channel in our 
 [community Slack][slack].
 
 ## apt Installation (Debian) [](installation-apt-debian)
@@ -39,7 +39,7 @@ wget --quiet -O - https://packagecloud.io/timescale/timescaledb/gpgkey | sudo ap
 sudo apt-get update
 
 # Now install appropriate package for PG version
-sudo apt-get install timescaledb-postgresql-:pg_version:
+sudo apt-get install timescaledb-2-postgresql-:pg_version:
 ```
 
 #### Configure your database
@@ -63,11 +63,7 @@ To get started you'll now need to restart PostgreSQL:
 sudo service postgresql restart
 ```
 
->:TIP: Our standard binary releases are licensed under the Timescale License,
-which allows to use all our capabilities.
-If you want to use a version that contains _only_ Apache 2.0 licensed
-code, you should install the package `timescaledb-oss-postgresql-:pg_version:`.
-
 [config]: /getting-started/configuring
 [contact]: https://www.timescale.com/contact
 [slack]: https://slack.timescale.com/
+[multi-node-basic]: /getting-started/setup-multi-node-basic

--- a/getting-started/installation-apt-ubuntu.md
+++ b/getting-started/installation-apt-ubuntu.md
@@ -1,6 +1,6 @@
 >:WARNING: These installation instructions will install the current Release Candidate
-for TimescaleDB 2.0, which includes the ability to setup [Multi-Node capabilities][multi-node-basic]. For
-more information, please [contact us][contact] or join the #multinode-beta channel in our 
+for TimescaleDB 2.0, which includes the ability to setup [multi-node capabilities][multi-node-basic]. For
+more information, please [contact us][contact] or join the #multinode channel in our 
 [community Slack][slack].
 
 ## apt Installation (Ubuntu) [](installation-apt-ubuntu)

--- a/getting-started/installation-apt-ubuntu.md
+++ b/getting-started/installation-apt-ubuntu.md
@@ -1,6 +1,6 @@
->:WARNING: Our scaling out capabilities are currently in BETA and
-are not available through this installation method. For more information,
-please [contact us][contact] or join the #multinode-beta channel in our 
+>:WARNING: These installation instructions will install the current Release Candidate
+for TimescaleDB 2.0, which includes the ability to setup [Multi-Node capabilities][multi-node-basic]. For
+more information, please [contact us][contact] or join the #multinode-beta channel in our 
 [community Slack][slack].
 
 ## apt Installation (Ubuntu) [](installation-apt-ubuntu)
@@ -40,7 +40,7 @@ sudo add-apt-repository ppa:timescale/timescaledb-ppa
 sudo apt-get update
 
 # Now install appropriate package for PG version
-sudo apt install timescaledb-postgresql-:pg_version:
+sudo apt install timescaledb-2-postgresql-:pg_version:
 ```
 
 #### Configure your database
@@ -64,12 +64,8 @@ To get started you'll now need to restart PostgreSQL:
 sudo service postgresql restart
 ```
 
->:TIP: Our standard binary releases are licensed under the Timescale License,
-which allows to use all our capabilities.
-If you want to use a version that contains _only_ Apache 2.0 licensed
-code, you should install the package `timescaledb-oss-postgresql-:pg_version:`.
-
 [ubuntu-releases]: http://releases.ubuntu.com/
 [config]: /getting-started/configuring
 [contact]: https://www.timescale.com/contact
 [slack]: https://slack.timescale.com/
+[multi-node-basic]: /getting-started/setup-multi-node-basic

--- a/getting-started/installation-docker.md
+++ b/getting-started/installation-docker.md
@@ -5,7 +5,7 @@
 Start a TimescaleDB instance, pulling our Docker image from [Docker Hub][] if it has not been already installed:
 
 ```bash
-docker run -d --name timescaledb -p 5432:5432 -e POSTGRES_PASSWORD=password timescale/timescaledb:latest-pg:pg_version:
+docker run -d --name timescaledb -p 5432:5432 -e POSTGRES_PASSWORD=password timescale/timescaledb:x.y.z-pg:pg_version:
 ```
 
 >:WARNING: The -p flag binds the container port to the host port, meaning
@@ -48,7 +48,7 @@ While the above `run` command will pull the Docker image on demand,
 you can also -- and for upgrades, **need to** -- explicitly pull our image from [Docker Hub][]:
 
 ```bash
-docker pull timescale/timescaledb:latest-pg:pg_version:
+docker pull timescale/timescaledb:x.y.z-pg:pg_version:
 ```
 
 When running a Docker image, if one prefers to store the data in a
@@ -71,7 +71,7 @@ docker volumes.
 >:TIP: Our standard binary releases are licensed under the Timescale License,
 which allows to use all our capabilities.
 If you want to use a version that contains _only_ Apache 2.0 licensed
-code, you should pull the tag `latest-pg:pg_version:-oss`.
+code, you should pull the tag `2.0.0-rc2-pg:pg_version:-oss`.
 
 ## Prebuilt with PostGIS [](postgis-docker)
 

--- a/getting-started/installation-homebrew.md
+++ b/getting-started/installation-homebrew.md
@@ -1,6 +1,6 @@
 >:WARNING: Our scaling out capabilities are currently in BETA and
 are not available through this installation method. For more information,
-please [contact us][contact] or join the #multinode-beta channel in our 
+please [contact us][contact] or join the #multinode channel in our 
 [community Slack][slack].
 
 ## Homebrew [](homebrew)

--- a/getting-started/installation-timescale-cloud.md
+++ b/getting-started/installation-timescale-cloud.md
@@ -1,6 +1,6 @@
 >:WARNING: Our scaling out capabilities are currently in BETA and
 are not available through this installation method. For more information,
-please [contact us][contact] or join the #multinode-beta channel in our 
+please [contact us][contact] or join the #multinode channel in our 
 [community Slack][slack].
 
 ## Installation (Timescale Cloud) [](installation-timescale-cloud)

--- a/getting-started/installation-ubuntu-ami.md
+++ b/getting-started/installation-ubuntu-ami.md
@@ -1,6 +1,6 @@
 >:WARNING: Our scaling out capabilities are currently in BETA and
 are not available through this installation method. For more information,
-please [contact us][contact] or join the #multinode-beta channel in our
+please [contact us][contact] or join the #multinode channel in our
 [community Slack][slack].
 
 ## Installing from an Amazon AMI (Ubuntu) [](installation-ubuntu-ami)

--- a/getting-started/installation-windows.md
+++ b/getting-started/installation-windows.md
@@ -1,6 +1,6 @@
 >:WARNING: Our scaling out capabilities are currently in BETA and
 are not available through this installation method. For more information,
-please [contact us][contact] or join the #multinode-beta channel in our 
+please [contact us][contact] or join the #multinode channel in our 
 [community Slack][slack].
 
 ## Windows ZIP Installer [](installation-windows)

--- a/getting-started/installation-yum.md
+++ b/getting-started/installation-yum.md
@@ -1,6 +1,6 @@
->:WARNING: Our scaling out capabilities are currently in BETA and
-are not available through this installation method. For more information,
-please [contact us][contact] or join the #multinode-beta channel in our 
+>:WARNING: These installation instructions will install the current Release Candidate
+for TimescaleDB 2.0, which includes the ability to setup [Multi-Node capabilities][multi-node-basic]. For
+more information, please [contact us][contact] or join the #multinode-beta channel in our 
 [community Slack][slack].
 
 ## yum Installation [](installation-yum)
@@ -52,7 +52,7 @@ EOL
 sudo yum update -y
 
 # Now install appropriate package for PG version
-sudo yum install -y timescaledb-postgresql-:pg_version:
+sudo yum install -y timescaledb-2-postgresql-:pg_version:
 ```
 
 #### Configure your database
@@ -74,14 +74,10 @@ To get started you'll need to restart PostgreSQL and add
 a `postgres` [superuser][createuser] (used in the rest of the docs). Please
 refer to your distribution for how to restart services.
 
->:TIP: Our standard binary releases are licensed under the Timescale License,
-which allows to use all our capabilities.
-If you want to use a version that contains _only_ Apache 2.0 licensed
-code, you should install the package `timescaledb-oss-postgresql-:pg_version:`.
-
 [pgdg]: https://yum.postgresql.org/repopackages.php
 [yuminstall]: https://wiki.postgresql.org/wiki/YUM_Installation
 [config]: /getting-started/configuring
 [createuser]: https://www.postgresql.org/docs/current/sql-createrole.html
 [contact]: https://www.timescale.com/contact
 [slack]: https://slack.timescale.com/
+[multi-node-basic]: /getting-started/setup-multi-node-basic

--- a/getting-started/installation-yum.md
+++ b/getting-started/installation-yum.md
@@ -1,6 +1,6 @@
 >:WARNING: These installation instructions will install the current Release Candidate
-for TimescaleDB 2.0, which includes the ability to setup [Multi-Node capabilities][multi-node-basic]. For
-more information, please [contact us][contact] or join the #multinode-beta channel in our 
+for TimescaleDB 2.0, which includes the ability to setup [multi-node capabilities][multi-node-basic]. For
+more information, please [contact us][contact] or join the #multinode channel in our 
 [community Slack][slack].
 
 ## yum Installation [](installation-yum)

--- a/getting-started/release-notes/changes-in-timescaledb-2.md
+++ b/getting-started/release-notes/changes-in-timescaledb-2.md
@@ -1,0 +1,290 @@
+# Changes in TimescaleDB 2.0
+
+TimescaleDB 2.0 introduces new features and capabilities to its advanced relational database for time-series data. Driven by user feedback and our experience building products like [Promscale](https://github.com/timescale/promscale), 2.0 is a major milestone and introduces the first multi-node, petabyte-scale relational database for time-series. In addition to multi-node capabilities, this release includes new features - and improvements to existing ones - focused on giving users more flexibility, control over their data and the ability to customize behavior to suit their needs.
+
+To facilitate many of the improvements in [TimescaleDB 2.0](https://github.com/timescale/timescaledb/releases/tag/2.0.0-rc1), several existing APIs and function definitions have been modified which may require updates to your existing code. 
+
+Most notably, the following features include updates and changes that may impact existing code using these interfaces. If your workloads use any of the features, this document covers each in detail to help you understand what - if any - action you need to take.
+
+*   **Dropping support for PostgreSQL versions 9.6 and 10:** As mentioned in [our upgrade documentation](https://docs.timescale.com/update-timescaledb), TimescaleDB 2.0 no longer supports older PostgreSQL versions. You will need to be running PostgreSQL version 11 or 12 to upgrade your TimescaleDB installation to 2.0.
+*   **Continuous Aggregates:** We have made major changes in the creation and management of continuous aggregates to address user feedback.
+*   **Data Retention and Compression Policies:**  All policies are now managed through a unified API and a consolidated set of Views.
+*   **Informational Views:** Based on user feedback and our desire to make TimescaleDB easy to manage, multiple information views have been consolidated for better clarity. 
+
+The following migration document provides more information on each of these API changes and how they affect users of TimescaleDB 1.x . We’ve also included a bit of information about the impetus for these changes and our design decisions. For a more in-depth coverage of APIs, as well as a detailed description of new capabilities included in 2.0, such as distributed hypertables and the ability to run user-defined actions (custom background jobs), please [review our updated documentation](https://docs.timescale.com/v2.0/main) (navigate to specific features of interest).
+
+Once you have read through this guide and understand the impact upgrading to the latest version may have on your existing application and infrastructure, please follow our [upgrade to TimescaleDB 2.0](https://docs.timescale.com/latest/using-timescaledb/update-timescale/update-db-2) documentation. You will find straight-forward instructions and recommendations to ensure everything is updated and works correctly.
+
+
+# Why we’ve made these changes
+
+It’s been two years since we released TimescaleDB 1.0 in October 2018 with the ambition to make it easy to scale PostgreSQL for time-series workloads. Since that initial release, we’ve added many new capabilities: support for compression, continuous aggregates, data lifecycle management, and numerous optimizations, as well as two new underlying PostgreSQL versions (11 and 12). At the same time, the core of TimescaleDB hasn’t changed significantly: we still have hypertables, auto-partitioning, query optimizations, and a basic user experience that many have come to appreciate because things “just work”. 
+
+Still, as with any technology solution, there are some things that we didn’t get 100% right in our first release. In particular, as usage of TimescaleDB has skyrocketed, many users have told us that our informational views aren’t always clear and consistent, nor do they provide enough detail on what is happening in the background. Likewise, while it is “easy” to create a continuous aggregate, it wasn’t always clear why aggregates sometimes returned no data, or new raw data is slow to be materialized. As a side effect of creating a continuous aggregate, data retention on hypertables can become blocked, and understanding how to re-enable it is a common support question.
+
+While our ambition to provide a solution that “just works” remains, too much “magic” and automation behind the scenes related to features like hypertables, compression, and continuous aggregations can cause outcomes not in line with user expectations or intentions. And, with a general database like PostgreSQL, the expected behavior varies widely depending on the use case (and users’ expertise). **This has led us to recommit to the user experience: simplifying APIs and making them more consistent, yet at the same time empowering users with more control to customize behaviors when needed.**
+
+For example, in TimescaleDB 2.0 we’ve separated the automation of refreshing continuous aggregate data from the core functionality, giving users the option to manually refresh the data and, if desired, add automation via a policy. This also makes this feature consistent with TimescaleDB’s other policy-driven features – such as retention, reordering, and compression – which offer both manual control and automation via policies. We have also opened up our jobs scheduling framework to enable user-defined actions, i.e, custom background jobs that users can define themselves.
+
+In the rest of this document, we go through each of the features and API changes in detail, and what users migrating from an earlier version of TimescaleDB should consider prior to updating to TimescaleDB 2.0. 
+
+
+# Working with hypertables
+
+In TimescaleDB 2.0, we have made changes to existing APIs for working with hypertables, as well as improvements to the related information views and size functions. These views and functions provide information about basic configuration, partitioning, data chunks, and disk size, and they also have been updated to work for distributed hypertables.
+
+
+## Creating hypertables and changing configuration
+
+The following APIs to create and configure hypertables have changed:
+
+
+
+*   [create_hypertable](https://docs.timescale.com/api#create_hypertable):  The `main_table` parameter has been renamed to `relation`, and additional parameters for distributed hypertables have been added.
+*   [set_chunk_time_interval](https://docs.timescale.com/v2.0/api#set_chunk_time_interval), [set_number_of_partitions](https://docs.timescale.com/v2.0/api#set_number_partitions), [add_dimension](https://docs.timescale.com/v2.0/api#add_dimension):  The `main_table` parameter has changed name to `hypertable`.
+
+## Viewing information about hypertables
+
+Consistent with our desire to improve visibility into all aspects of TimescaleDB configuration, the following views and functions about hypertable information have been updated or added:
+
+*   [timescaledb_information.hypertables](https://docs.timescale.com/v2.0/api#timescaledb_information-hypertables): 
+    *   The view with basic information about hypertables has been renamed from the singular “hypertable”
+    *   Some columns have new names for consistency with other views
+    *   Table size information has been removed and made available through new size functions discussed later
+    *   Additional columns have been added related to distributed hypertables
+    *   The view no longer shows internal hypertables for continuous aggregates and compression
+    *   For continuous aggregates, the internal materialized hypertable name is available in the `timescaledb_information.continuous_aggregates` view.
+*   [timescaledb_information.dimensions](https://docs.timescale.com/v2.0/api#timescaledb_information-dimensions):  A new view allows users to see partitioning information and settings for various dimensions, such as the chunk time interval or number of space partitions used in a hypertable.
+*   [timescaledb_information.chunks](https://docs.timescale.com/v2.0/api#timescaledb_information-chunks):   A new view allows users to see information about individual data chunks of all hypertables, including the tablespace or data node on which each chunk is stored.
+*   [show_chunks(relation)](https://docs.timescale.com/v2.0/api#show_chunks):  The function now requires providing a hypertable or continuous aggregate identifier as the first argument, which is consistent with `drop_chunks(relation)`. Previously, it was possible to view the chunks of all hypertables by eliding the hypertable argument. To view all chunks in the database, we instead recommend using the new chunks view described above.
+
+These views can be used together to answer certain questions.  For example:
+
+**Q:  Get all chunks written to tablespace “ts1” during the past month:**
+
+```SQL
+SELECT * FROM timescaledb_information.chunks 
+  WHERE hypertable_name = 'conditions' 
+    AND chunk_tablespace = 'ts1' 
+    AND range_start > now() - INTERVAL '1 month';
+```
+
+**Q:  Get compression status of all chunks on hypertables with compression enabled:**
+
+```SQL
+SELECT h.hypertable_schema, h.hypertable_name, 
+  chunk_schema, chunk_name, 
+  range_start, range_end, is_compressed 
+FROM timescaledb_information.chunks c 
+  INNER JOIN timescaledb_information.hypertables h
+    ON (c.hypertable_schema = h.hypertable_schema 
+      AND c.hypertable_name = h.hypertable_name) 
+  WHERE h.compression_enabled = true;
+```
+
+## New functions for size information 
+
+Information views no longer display size information about hypertables and other objects, instead size information is available through a set of functions that all return the size in number of bytes. Removing size information makes the views faster since the information is often read dynamically from disk, or, in the case of distributed hypertables, read across a network. 
+
+Size functions are also split into basic and detailed ones. The former class of functions return only a single aggregate value and can be easily applied in queries, while the detailed functions return multiple columns and (possibly) multiple rows of information.
+
+*   [hypertable_detailed_size(hypertable)](https://docs.timescale.com/v2.0/api#hypertable_detailed_size):  The function has been renamed from `hypertable_relation_size(hypertable)`.  Further, if the hypertable is distributed, it will return multiple rows, one per each of the hypertable’s data nodes.
+*   [hypertable_size(hypertable)](https://docs.timescale.com/v2.0/api#hypertable_size):  Returns a single value giving the aggregated hypertable size, including both tables (chunks) and indexes.
+*   [chunks_detailed_size(hypertable)](https://docs.timescale.com/v2.0/api#chunks_detailed_size):  Returns the size information about each of the chunks in a hypertable. On a distributed hypertable, this function returns one row per data node that holds a copy of the chunk.
+*   [hypertable_index_size(index)](https://docs.timescale.com/v2.0/api#hypertable_index_size): Returns the aggregate number of bytes corresponding to a hypertable index across all chunks.
+*   [approximate_row_count(relation)](https://docs.timescale.com/v2.0/api#approximate_row_count):  The function has been renamed from `hypertable_approximate_row_count`, but can now also be called on non-hypertables.
+
+In previous versions of TimescaleDB, you could get size information for all hypertables in the `hypertable` view. In TimescaleDB 2.0, you can now instead combine the new `hypertables` view with size functions to achieve a similar result:
+
+
+```SQL
+SELECT hypertable_name, hypertable_size(hypertable_name::regclass) FROM timescaledb_information.hypertables;
+
+ hypertable_name | hypertable_size
+-----------------+-----------------
+ devices         |      	360448
+ conditions      |      	253952
+```
+
+# Continuous Aggregates
+
+Major changes have been made to Continuous Aggregates in TimescaleDB 2.0 to better clarify this feature.
+
+First, Continuous Aggregates have always been more closely aligned with Materialized Views in PostgreSQL. Therefore, creating a continuous aggregate now uses `CREATE MATERIALIZED VIEW`, rather than `CREATE VIEW`.
+
+Second, the continuous aggregate API now separates the explicit mechanism for updating a continuous aggregate, and the policy that automates the process of keeping a continuous aggregate up-to-date.  This change both simplifies the continuous aggregate API in TimescaleDB 2.0, provides more flexibility to users (especially when combined with user-defined actions and a newly-exposed API for scheduling jobs directly), and makes it consistent with other policy automation in TimescaleDB 2.0:
+
+Action API                    | Policy API for Automation
+------------------------------|--------------------------
+`drop_chunks`                 | `add_retention_policy`
+`reorder_chunk`               | `add_reorder_policy`
+`compress_chunk`              | `add_compression_policy`
+`refresh_continuous_aggregate`|`add_continuous_aggregate_policy`
+
+
+In practice, this means that creating a continuous aggregate in TimescaleDB 2.0 is now a two-step process:
+
+1. Create via a [CREATE MATERIALIZED VIEW](https://docs.timescale.com/v2.0/api#continuous_aggregate-create_view) statement
+2. Add an (automation) policy on the continuous aggregate via a separate [API function call](https://docs.timescale.com/v2.0/api#add_continuous_aggregate_policy)
+
+```SQL
+CREATE MATERIALIZED VIEW conditions_by_2h
+  WITH (timescaledb.continuous, 
+    timescaledb.materialized_only=false)
+  AS 
+    SELECT time_bucket('2 hours', time) as bin, 
+      COUNT(device) as value
+    FROM conditions
+    GROUP BY bin
+  WITH NO DATA;
+
+SELECT add_continuous_aggregate_policy(
+  continuous_aggregate => 'conditions_by_2h', 
+  start_offset         => '4 weeks', 
+  end_offset           => '2 hours',
+  schedule_interval    => '1 hour');
+```
+
+In the example above, `CREATE MATERIALIZED VIEW `creates a continuous aggregate without any automation yet associated with it.  Notice also that  `WITH NO DATA` is specified at the end. This prevents the view from materializing data at creation time, instead deferring the population of aggregated data until the policy runs as a background job or as part of a manual refresh. Therefore, we that users create continuous aggregates using the `WITH NO DATA` option, especially if a significant amount of historical data will be materialized.
+
+Once the Continuous Aggregate is created, calling `add_continuous_aggregate_policy` creates a continuous aggregate policy, which automatically materializes or refreshes the data following the schedule and rules provided. Inputs to the policy function include the continuous aggregate name, a refresh window, and a schedule interval.  The refresh window is specified by the start and end offsets, which are used to calculate a new refresh window every time the policy runs by subtracting the offsets from the current time (as normally returned by the function `now()`).
+
+
+## Understanding Continuous Aggregate Policies
+
+It is worth noting the way that “start_offset” and “end_offset” work as new data arrives and is added to the source Hypertables.
+
+The above example sets the refresh interval as between four weeks and two hours ago (start_offset and end_offset respectively). Therefore, if any late data arrives with timestamps within the last four weeks and is backfilled into the source hypertable, then the continuous aggregate view is updated with this old data the next time the policy executes. 
+
+This policy will, in the worst case, materialize the whole window every time it runs if data at least four weeks old continues to arrive and be inserted into the source Hypertables.  However, since a continuous aggregate tracks changes since the last refresh, it will in most cases materialize a subset of the window that corresponds to the data that has actually changed. 
+
+In this example, data backfilled more than 4 weeks ago is not rematerialized, nor does the continuous aggregate include data less than 2 hours old.  However, _querying the continuous aggregate view can still return aggregates about the latest data, and not just aggregated data more than 2 hours old, based on support for [real-time aggregation](https://docs.timescale.com/latest/using-timescaledb/continuous-aggregates#real-time-aggregates)_, specified as before with the `timescaledb.materialized_only=false` parameter. Real-time aggregates are still the default setting unless otherwise specified.
+
+Finally, it is recommended that the `end_offset` lags the current time by at least one `time_bucket `as defined in the aggregate SQL, otherwise it might affect performance when inserting new data, which usually is written to what would be the latest bucket.  In TimescaleDB 1.x, the `refresh_lag` parameter was used for a similar purpose, but we found that  using it correctly was more difficult to understand.
+
+
+## Manually refreshing regions of continuous aggregates
+
+TimescaleDB 2.0 removes support for `REFRESH MATERIALIZED VIEW` in favor of the new, more flexible function, [refresh_continuous_aggregate](https://docs.timescale.com/v2.0/api#refresh_continuous_aggregate), which enables a user to refresh a specific window in a continuous aggregate:
+
+
+```SQL
+CALL refresh_continuous_aggregate(
+  continuous_aggregate => 'conditions_by_2h',
+  window_start         => '2020-05-01', 
+  window_end           => '2020-05-03');
+```
+
+Users can use this command explicitly; a typical use of this command is to manually refresh historical data while creating a continuous aggregate policy to aggregate new data. It is even possible to build custom continuous aggregation policies using this function within the new user-defined action framework which are then scheduled via `add_job`. 
+
+Note that` refresh_continuous_aggregate` only recomputes the aggregated time buckets that completely fall inside the given refresh window boundaries and are in a region that has seen changes in the underlying hypertable. Thus, if no changes have occurred in the underlying source data (that is, no data has been backfilled to the region or no updates to existing data have been made), no materialization will be performed either over that region. This behavior is similar to the continuous aggregate policy and ensures more efficient operation.
+
+
+## Using data retention and continuous aggregates together [](retention-and-caggs)
+
+With greater power and flexibility also comes a greater responsibility to understand how features interact. Specifically, users should understand the interactions between data retention policy settings and continuous aggregate settings. 
+
+Before starting the upgrade to TimescaleDB 2.0, **we highly recommend checking the database log for errors related to failed retention policies that were occurring in TimescaleDB 1.x** and then either remove them or update them to be compatible with existing continuous aggregates. Any remaining retention policies that are still incompatible with the `ignore_invalidation_older_than `setting will automatically be disabled with a notice during the upgrade.
+
+As an example, if a data retention policy on a hypertable is set for `drop_after => '4 weeks'`, then the policy associated with a continuous aggregate on that same hypertable should have a `start_offset` less than or equal to 4 weeks.  Similarly, any manual call to `refresh_continuous_aggregate` should likely specify a `window_start` that’s also less than the date from 4 weeks ago. 
+
+If not understood properly, users could overwrite existing aggregated data in continuous aggregates with empty data by recomputing data over a now-dropped time window of data, not likely the result a user was expecting. Instead, users seeking to keep only a certain time window of data in their continuous aggregate view should create a data retention policy on the continuous aggregate.
+
+**This differs significantly from how TimescaleDB 1.x handled conflicts between retention policies and continuous aggregates.**
+
+Previously, if the continuous aggregation setting `ignore_invalidation_older_than` overlapped with data that would be dropped by a retention policy, the retention policy would silently fail.  Making the retention policy work again required users to modify settings in either the retention policy or the continuous aggregate, and even then some data wasn’t always materialized as expected. 
+
+After upgrading to TimescaleDB 2.0, **retention policies will no longer fail due to incompatibilities with continuous aggregates** and users have to ensure that retention and continuous aggregate policies have the desired interplay. 
+
+## Differences in the handling of backfill on continuous aggregates
+
+In TimescaleDB 1.x, data that was backfilled into hypertables wasn’t handled optimally; modification of any hypertable data, regardless of how old, would cause the continuous aggregate materializer job to restart from the point of the earliest backfill and then it would materialize from that point forward. Unfortunately, this could also cause the materializer to get “stuck”, since the background job only processed a limited amount of data per run, as governed by the `max_interval_per_job` setting. When this happened, one job run could potentially force the next job to start all over again. 
+
+To prevent this, the `ignore_invalidation_older_than` setting could be used to ignore backfill data older than a specified interval (e.g., ignore backfill older than 1 week), preventing the materializer from restarting if hypertable data was modified beyond this interval boundary. However, this would also stop TimescalDB 1.x from tracking changes in the underlying data beyond the `ignore_invalidation_older_than` threshold too. This meant that it was not possible to revert this setting later to a larger interval (e.g., 1 month) without potentially having a mismatch between the raw data and the aggregated data in the continuous aggregate.
+
+In contrast, TimescaleDB 2.0 never stops tracking backfill, and to avoid materializing too much historical data, one should simply use a refresh window that does not include that region of data. The backfilled region can always be refreshed at a later time, either manually or via a policy.
+
+To ensure that previously ignored backfill can be refreshed after the upgrade to TimescaleDB 2.0, the upgrade process will mark the region older than the `ignore_invalidation_older_than` threshold as “requiring refresh”. This allows a manual refresh to bring a continuous aggregate up-to-date with the underlying source data. If the `ignore_invalidation_older_than` threshold was reset to a larger interval at some point, we recommend setting it back to the smaller interval prior to upgrading to ensure that all the backfill can be refreshed, if one so desires. 
+
+Note again, however, that if backfill was previously ignored due to a retention policy on the underlying hypertable, a manual refresh of older data into a continuous aggregate could remove data when hypertable chunks have been dropped due to a data retention policy as discussed in the previous section.
+
+## Viewing information about continuous aggregates
+
+In TimescaleDB 2.0, views surrounding continuous aggregates (and other policies) have been simplified and generalized.
+
+### Changes and Additions
+*   [timescaledb_information.continuous_aggregates](https://docs.timescale.com/v2.0/api#timescaledb_information-continuous_aggregate): now provides information related to the materialized view, which includes the view name and owner, the real time aggregation flag, the materialization and the view definition (the select statement defining the view)
+*   [timescaledb_information.jobs](https://docs.timescale.com/v2.0/api#timescaledb_information-jobs): displays information for all policies including continuous aggregates  
+*   [Timescaledb_information.job_stats](https://docs.timescale.com/v2.0/api#timescaledb_information-jobs_stats): displays job statistics related to all jobs
+
+### Removed
+* [timescaledb_information.continuous_aggregate_stats](https://docs.timescale.com/v1.7/api#timescaledb_information-continuous_aggregate_stats): Removed in favor of the `job_stats` view mentioned above.
+
+## Updating existing continuous aggregates [](updating-continuous-aggregates)
+
+If you have existing continuous aggregates and you update your database to TimescaleDB 2.0, the update scripts will automatically reconfigure your continuous aggregates to use the new framework.
+
+In particular, the update process should:
+
+*   Maintain the same view schema, name, owner, and view definition as before, as well as the setting for `materialized_only`.
+*   Schedule the refresh to run at the same interval as before (although the parameter is now named `schedule_interval` rather than `refresh_interval`).
+*   Automatically configure `start_offset` to the same offset as specified by the old `ignore_invalidation_older_than` setting. 
+*   Automatically configure `end_offset` to have an offset from `now()` equivalent to  the old `refresh_lag` setting.
+*   Mark all the data older than the interval `ignore_invalidation_older_than` as out-of-date, so that it can be refreshed.
+*   Disable any retention policies that are failing due to being incompatible with the current setting of `ignore_invalidation_older_than` on a continuous aggregate (as described above). Disabled policies will remain post upgrade, but will not be scheduled to run (`scheduled=false `in` timescaledb_information.jobs`). If failing policies were to be migrated to 2.0 they would start to work again, but likely with unintended consequences. Therefore, any retention policies that are disabled post update should have their settings carefully reviewed before being enabled again.
+
+You can validate these in the proper informational views, given above.
+
+
+# Other Superficial API Changes
+
+Other minor changes were made to various APIs for greater understandability and consistency, including in the following areas.
+
+## Data Retention
+
+### Changes and Additions
+*   [drop_chunks](https://docs.timescale.com/v2.0/api#drop_chunks): This function now requires specifying a hypertable or continuous aggregate as the first argument, and does not allow dropping chunks across all hypertables in a database.  Additionally, the arguments `cascade` and `cascade_to_materializations` were removed (and behave as if the arguments were set to `false` in earlier versions). In TimescaleDB 2.0, we instead recommend creating a separate retention policy on each continuous aggregate. 
+*   [add_retention_policy](https://docs.timescale.com/v2.0/api#add_retention_policy), [remove_retention_policy](https://docs.timescale.com/v2.0/api#remove_retention_policy):  Creating (or removing) a data retention policy now have explicit functions. Additionally, the arguments `cascade` and `cascade_to_materializations` were removed (and behave as if the arguments were set to `false` in earlier versions).
+*   [timescaledb_information.jobs](https://docs.timescale.com/v2.0/api#jobs): General information about data retention policies are now available in the main jobs view
+
+### Removed
+*   [add_drop_chunks_policy](https://docs.timescale.com/v1.7/api#add_drop_chunks_policy): removed in favor of the explicit functions above
+*   [timescaledb_information.drop_chunks_policies](https://docs.timescale.com/v1.7/api#timescaledb_information-drop_chunks_policies) view has been removed in favor of the more general jobs view.
+
+
+## Compression
+
+### Changes and Additions
+*   [add_compression_policy](https://docs.timescale.com/v2.0/api#add_compression_policy), [remove_compression_policy](https://docs.timescale.com/v2.0/api#remove_compression_policy):  Creating (or removing) a compression policy now have explicit functions
+*   [hypertable_compression_stats(hypertable)](https://docs.timescale.com/v2.0/api#hypertable_compression_stats): The function  returns statistics only for hypertables with compression enabled
+*   [chunk_compression_stats(hypertable)](https://docs.timescale.com/v2.0/api#chunk_compression_stats):  The function returns information about currently compressed chunks
+*   [timescaledb_information.compression_settings](https://docs.timescale.com/v2.0/api#timescaledb_information-compression_settings): This new view gives information about the compression settings on hypertables
+*   [timescaledb_information.jobs](https://docs.timescale.com/v2.0/api#timescaledb_information-jobs): General information about compression policies are now available in the main jobs view
+
+### Removed
+* [add_compress_chunk_policy](https://docs.timescale.com/v1.7/api#add_compress_chunks_policy): removed in favor of the explicit functions above
+* [timescaledb_information.compressed_hypertable_stats](https://docs.timescale.com/v1.7/api#timescaledb_information-compressed_hypertable_stats): removed in favor of the new `hypertable_compression_stats(hypertable)` function linked above
+* [timescaledb_information.compressed_chunk_stats](https://docs.timescale.com/v1.7/api#timescaledb_information-compressed_chunk_stats): removed in favor of the new `chunk_compression_stats(hypertable)` function linked above
+
+## Managing policies and other jobs
+
+TimescaleDB 2.0 introduces user-defined actions and creates a more unified jobs API. Now, jobs created by the TimescaleDB policies and for user-defined actions can be managed and viewed through a single API.
+
+
+
+*   `add_job:` Adds a new user-defined action to the job scheduling framework.
+*   `alter_job:` Changes settings for existing jobs.  Renamed from `alter_job_schedule` in previous versions,  it introduces additional settings, including  `scheduled` to pause and resume jobs, and `config` to change policy or action-specific settings.
+*   `run_job`: Manually executes a job immediately and in the foreground.
+*   `delete_job`: Removes the job from the scheduler.  This is equivalent to functions that remove policies for built-in actions (e.g., `remove_retention_policy`). 
+*   `timescaledb_information.jobs`:  The new view provides all job settings available, and it replaces all policy-specific views.
+*   `timescaledb_information.job_stats`:  The view presents statistics of executing jobs for policies and actions.
+
+
+## License information
+
+In TimescaleDB 2.0, all features which had been classified previously as “enterprise” have become “community” features and are available for free under the Timescale License.  As such, the need for an “enterprise license” to unlock any features has been removed; all features are available either under the community Timescale License or under the open-source Apache-2 License. [This blog post](https://blog.timescale.com/blog/building-open-source-business-in-cloud-era-v2/) explains the changes. The following changes were made to license API:
+
+
+
+*   [timescaledb_information.license](https://docs.timescale.com/v1.7/api#timescaledb_information-license):  This view has been removed, as it primarily provided information on the enterprise license key’s expiration date, which is no longer applicable. The current license used by the extension can instead be viewed in the GUC below.
+*   `timescaledb.license`: This GUC value (which replaces the former [timescaledb.license_key](https://docs.timescale.com/latest/api#timescaledb_license-key) GUC) can take the value `timescale` or `apache`. It can be set only at startup (in the postgresql.conf configuration file or on the server command line), and allows limiting access to certain features by license. For example, setting the license to `apache` allows access to only Apache-2 licensed features.

--- a/getting-started/release-notes/changes-in-timescaledb-2.md
+++ b/getting-started/release-notes/changes-in-timescaledb-2.md
@@ -1,62 +1,122 @@
 # Changes in TimescaleDB 2.0
 
-TimescaleDB 2.0 introduces new features and capabilities to its advanced relational database for time-series data. Driven by user feedback and our experience building products like [Promscale](https://github.com/timescale/promscale), 2.0 is a major milestone and introduces the first multi-node, petabyte-scale relational database for time-series. In addition to multi-node capabilities, this release includes new features - and improvements to existing ones - focused on giving users more flexibility, control over their data and the ability to customize behavior to suit their needs.
+TimescaleDB 2.0 introduces new features and capabilities to its advanced relational 
+database for time-series data. Driven by user feedback and our experience building 
+products like [Promscale](https://github.com/timescale/promscale), 2.0 is a major 
+milestone and introduces the first multi-node, petabyte-scale relational database 
+for time-series. In addition to multi-node capabilities, this release includes new 
+features - and improvements to existing ones - focused on giving users more flexibility,
+ control over their data and the ability to customize behavior to suit their needs.
 
-To facilitate many of the improvements in [TimescaleDB 2.0](https://github.com/timescale/timescaledb/releases/tag/2.0.0-rc1), several existing APIs and function definitions have been modified which may require updates to your existing code. 
+To facilitate many of the improvements in [TimescaleDB 2.0](https://github.com/timescale/timescaledb/releases/tag/2.0.0-rc1),
+ several existing APIs and function definitions have been modified which may require updates to your existing code. 
 
-Most notably, the following features include updates and changes that may impact existing code using these interfaces. If your workloads use any of the features, this document covers each in detail to help you understand what - if any - action you need to take.
+Most notably, the following features include updates and changes that may impact 
+existing code using these interfaces. If your workloads use any of the features, 
+this document covers each in detail to help you understand what - if any - action 
+you need to take.
 
-*   **Dropping support for PostgreSQL versions 9.6 and 10:** As mentioned in [our upgrade documentation](https://docs.timescale.com/update-timescaledb), TimescaleDB 2.0 no longer supports older PostgreSQL versions. You will need to be running PostgreSQL version 11 or 12 to upgrade your TimescaleDB installation to 2.0.
-*   **Continuous Aggregates:** We have made major changes in the creation and management of continuous aggregates to address user feedback.
-*   **Data Retention and Compression Policies:**  All policies are now managed through a unified API and a consolidated set of Views.
-*   **Informational Views:** Based on user feedback and our desire to make TimescaleDB easy to manage, multiple information views have been consolidated for better clarity. 
+*   **Dropping support for PostgreSQL versions 9.6 and 10:** As mentioned in 
+[our upgrade documentation](https://docs.timescale.com/update-timescaledb), TimescaleDB 2.0
+ no longer supports older PostgreSQL versions. You will need to be running PostgreSQL
+  version 11 or 12 to upgrade your TimescaleDB installation to 2.0.
+*   **Continuous Aggregates:** We have made major changes in the creation and management 
+of continuous aggregates to address user feedback.
+*   **Data Retention and Compression Policies:**  All policies are now managed through a 
+unified API and a consolidated set of Views.
+*   **Informational Views:** Based on user feedback and our desire to make TimescaleDB 
+easy to manage, multiple information views have been consolidated for better clarity. 
 
-The following migration document provides more information on each of these API changes and how they affect users of TimescaleDB 1.x . We’ve also included a bit of information about the impetus for these changes and our design decisions. For a more in-depth coverage of APIs, as well as a detailed description of new capabilities included in 2.0, such as distributed hypertables and the ability to run user-defined actions (custom background jobs), please [review our updated documentation](https://docs.timescale.com/v2.0/main) (navigate to specific features of interest).
+The following migration document provides more information on each of these API changes 
+and how they affect users of TimescaleDB 1.x . We’ve also included a bit of information 
+about the impetus for these changes and our design decisions. For a more in-depth coverage
+ of APIs, as well as a detailed description of new capabilities included in 2.0, such as 
+ distributed hypertables and the ability to run user-defined actions (custom background jobs),
+  please [review our updated documentation](https://docs.timescale.com/v2.0/main) 
+  (navigate to specific features of interest).
 
-Once you have read through this guide and understand the impact upgrading to the latest version may have on your existing application and infrastructure, please follow our [upgrade to TimescaleDB 2.0](https://docs.timescale.com/latest/using-timescaledb/update-timescale/update-db-2) documentation. You will find straight-forward instructions and recommendations to ensure everything is updated and works correctly.
-
-
-# Why we’ve made these changes
-
-It’s been two years since we released TimescaleDB 1.0 in October 2018 with the ambition to make it easy to scale PostgreSQL for time-series workloads. Since that initial release, we’ve added many new capabilities: support for compression, continuous aggregates, data lifecycle management, and numerous optimizations, as well as two new underlying PostgreSQL versions (11 and 12). At the same time, the core of TimescaleDB hasn’t changed significantly: we still have hypertables, auto-partitioning, query optimizations, and a basic user experience that many have come to appreciate because things “just work”. 
-
-Still, as with any technology solution, there are some things that we didn’t get 100% right in our first release. In particular, as usage of TimescaleDB has skyrocketed, many users have told us that our informational views aren’t always clear and consistent, nor do they provide enough detail on what is happening in the background. Likewise, while it is “easy” to create a continuous aggregate, it wasn’t always clear why aggregates sometimes returned no data, or new raw data is slow to be materialized. As a side effect of creating a continuous aggregate, data retention on hypertables can become blocked, and understanding how to re-enable it is a common support question.
-
-While our ambition to provide a solution that “just works” remains, too much “magic” and automation behind the scenes related to features like hypertables, compression, and continuous aggregations can cause outcomes not in line with user expectations or intentions. And, with a general database like PostgreSQL, the expected behavior varies widely depending on the use case (and users’ expertise). **This has led us to recommit to the user experience: simplifying APIs and making them more consistent, yet at the same time empowering users with more control to customize behaviors when needed.**
-
-For example, in TimescaleDB 2.0 we’ve separated the automation of refreshing continuous aggregate data from the core functionality, giving users the option to manually refresh the data and, if desired, add automation via a policy. This also makes this feature consistent with TimescaleDB’s other policy-driven features – such as retention, reordering, and compression – which offer both manual control and automation via policies. We have also opened up our jobs scheduling framework to enable user-defined actions, i.e, custom background jobs that users can define themselves.
-
-In the rest of this document, we go through each of the features and API changes in detail, and what users migrating from an earlier version of TimescaleDB should consider prior to updating to TimescaleDB 2.0. 
+Once you have read through this guide and understand the impact upgrading to the latest
+ version may have on your existing application and infrastructure, please follow our 
+ [upgrade to TimescaleDB 2.0](https://docs.timescale.com/latest/using-timescaledb/update-timescale/update-db-2)
+  documentation. You will find straight-forward instructions and recommendations to ensure 
+  everything is updated and works correctly.
 
 
-# Working with hypertables
+# Why we’ve made these changes [](why-changes)
 
-In TimescaleDB 2.0, we have made changes to existing APIs for working with hypertables, as well as improvements to the related information views and size functions. These views and functions provide information about basic configuration, partitioning, data chunks, and disk size, and they also have been updated to work for distributed hypertables.
+It’s been two years since we released TimescaleDB 1.0 in October 2018 with the ambition 
+to make it easy to scale PostgreSQL for time-series workloads. Since that initial release, 
+we’ve added many new capabilities: support for compression, continuous aggregates, data 
+lifecycle management, and numerous optimizations, as well as two new underlying PostgreSQL 
+versions (11 and 12). At the same time, the core of TimescaleDB hasn’t changed significantly: 
+we still have hypertables, auto-partitioning, query optimizations, and a basic user 
+experience that many have come to appreciate because things “just work”. 
+
+Still, as with any technology solution, there are some things that we didn’t get 100% 
+right in our first release. In particular, as usage of TimescaleDB has skyrocketed, many 
+users have told us that our informational views aren’t always clear and consistent, nor 
+do they provide enough detail on what is happening in the background. Likewise, while it 
+is “easy” to create a continuous aggregate, it wasn’t always clear why aggregates sometimes 
+returned no data, or new raw data is slow to be materialized. As a side effect of creating 
+a continuous aggregate, data retention on hypertables can become blocked, and understanding 
+how to re-enable it is a common support question.
+
+While our ambition to provide a solution that “just works” remains, too much “magic” and 
+automation behind the scenes related to features like hypertables, compression, and continuous 
+aggregations can cause outcomes not in line with user expectations or intentions. And, with 
+a general database like PostgreSQL, the expected behavior varies widely depending on the use 
+case (and users’ expertise). **This has led us to recommit to the user experience: simplifying 
+APIs and making them more consistent, yet at the same time empowering users with more control 
+to customize behaviors when needed.**
+
+For example, in TimescaleDB 2.0 we’ve separated the automation of refreshing continuous aggregate 
+data from the core functionality, giving users the option to manually refresh the data and, if 
+desired, add automation via a policy. This also makes this feature consistent with TimescaleDB’s 
+other policy-driven features – such as retention, reordering, and compression – which offer both 
+manual control and automation via policies. We have also opened up our jobs scheduling framework 
+to enable user-defined actions, i.e, custom background jobs that users can define themselves.
+
+In the rest of this document, we go through each of the features and API changes in detail, and 
+what users migrating from an earlier version of TimescaleDB should consider prior to updating to TimescaleDB 2.0. 
+
+
+# Working with hypertables [](hypertables)
+
+In TimescaleDB 2.0, we have made changes to existing APIs for working with hypertables, as well 
+as improvements to the related information views and size functions. These views and functions 
+provide information about basic configuration, partitioning, data chunks, and disk size, and they 
+also have been updated to work for distributed hypertables.
 
 
 ## Creating hypertables and changing configuration
 
 The following APIs to create and configure hypertables have changed:
 
-
-
 *   [create_hypertable](https://docs.timescale.com/api#create_hypertable):  The `main_table` parameter has been renamed to `relation`, and additional parameters for distributed hypertables have been added.
 *   [set_chunk_time_interval](https://docs.timescale.com/v2.0/api#set_chunk_time_interval), [set_number_of_partitions](https://docs.timescale.com/v2.0/api#set_number_partitions), [add_dimension](https://docs.timescale.com/v2.0/api#add_dimension):  The `main_table` parameter has changed name to `hypertable`.
 
 ## Viewing information about hypertables
 
-Consistent with our desire to improve visibility into all aspects of TimescaleDB configuration, the following views and functions about hypertable information have been updated or added:
+Consistent with our desire to improve visibility into all aspects of TimescaleDB configuration, 
+the following views and functions about hypertable information have been updated or added:
 
 *   [timescaledb_information.hypertables](https://docs.timescale.com/v2.0/api#timescaledb_information-hypertables): 
-    *   The view with basic information about hypertables has been renamed from the singular “hypertable”
-    *   Some columns have new names for consistency with other views
-    *   Table size information has been removed and made available through new size functions discussed later
-    *   Additional columns have been added related to distributed hypertables
-    *   The view no longer shows internal hypertables for continuous aggregates and compression
+    *   The view with basic information about hypertables has been renamed from the singular “hypertable”.
+    *   Some columns have new names for consistency with other views.
+    *   Table size information has been removed and made available through new size functions discussed later.
+    *   Additional columns have been added related to distributed hypertables.
+    *   The view no longer shows internal hypertables for continuous aggregates and compression.
     *   For continuous aggregates, the internal materialized hypertable name is available in the `timescaledb_information.continuous_aggregates` view.
-*   [timescaledb_information.dimensions](https://docs.timescale.com/v2.0/api#timescaledb_information-dimensions):  A new view allows users to see partitioning information and settings for various dimensions, such as the chunk time interval or number of space partitions used in a hypertable.
-*   [timescaledb_information.chunks](https://docs.timescale.com/v2.0/api#timescaledb_information-chunks):   A new view allows users to see information about individual data chunks of all hypertables, including the tablespace or data node on which each chunk is stored.
-*   [show_chunks(relation)](https://docs.timescale.com/v2.0/api#show_chunks):  The function now requires providing a hypertable or continuous aggregate identifier as the first argument, which is consistent with `drop_chunks(relation)`. Previously, it was possible to view the chunks of all hypertables by eliding the hypertable argument. To view all chunks in the database, we instead recommend using the new chunks view described above.
+*   [timescaledb_information.dimensions](https://docs.timescale.com/v2.0/api#timescaledb_information-dimensions):  A new view allows 
+users to see partitioning information and settings for various dimensions, such as the chunk time interval or 
+number of space partitions used in a hypertable.
+*   [timescaledb_information.chunks](https://docs.timescale.com/v2.0/api#timescaledb_information-chunks):   A new view allows users 
+to see information about individual data chunks of all hypertables, including the tablespace or data node on which 
+each chunk is stored.
+*   [show_chunks(relation)](https://docs.timescale.com/v2.0/api#show_chunks):  The function now requires providing a 
+hypertable or continuous aggregate identifier as the first argument, which is consistent with `drop_chunks(relation)`. 
+Previously, it was possible to view the chunks of all hypertables by eliding the hypertable argument. To view all 
+chunks in the database, we instead recommend using the new chunks view described above.
 
 These views can be used together to answer certain questions.  For example:
 
@@ -84,17 +144,30 @@ FROM timescaledb_information.chunks c
 
 ## New functions for size information 
 
-Information views no longer display size information about hypertables and other objects, instead size information is available through a set of functions that all return the size in number of bytes. Removing size information makes the views faster since the information is often read dynamically from disk, or, in the case of distributed hypertables, read across a network. 
+Information views no longer display size information about hypertables and other objects, instead 
+size information is available through a set of functions that all return the size in number of 
+bytes. Removing size information makes the views faster since the information is often read dynamically 
+from disk, or, in the case of distributed hypertables, read across a network. 
 
-Size functions are also split into basic and detailed ones. The former class of functions return only a single aggregate value and can be easily applied in queries, while the detailed functions return multiple columns and (possibly) multiple rows of information.
+Size functions are also split into basic and detailed ones. The former class of functions return 
+only a single aggregate value and can be easily applied in queries, while the detailed functions 
+return multiple columns and (possibly) multiple rows of information.
 
-*   [hypertable_detailed_size(hypertable)](https://docs.timescale.com/v2.0/api#hypertable_detailed_size):  The function has been renamed from `hypertable_relation_size(hypertable)`.  Further, if the hypertable is distributed, it will return multiple rows, one per each of the hypertable’s data nodes.
-*   [hypertable_size(hypertable)](https://docs.timescale.com/v2.0/api#hypertable_size):  Returns a single value giving the aggregated hypertable size, including both tables (chunks) and indexes.
-*   [chunks_detailed_size(hypertable)](https://docs.timescale.com/v2.0/api#chunks_detailed_size):  Returns the size information about each of the chunks in a hypertable. On a distributed hypertable, this function returns one row per data node that holds a copy of the chunk.
-*   [hypertable_index_size(index)](https://docs.timescale.com/v2.0/api#hypertable_index_size): Returns the aggregate number of bytes corresponding to a hypertable index across all chunks.
-*   [approximate_row_count(relation)](https://docs.timescale.com/v2.0/api#approximate_row_count):  The function has been renamed from `hypertable_approximate_row_count`, but can now also be called on non-hypertables.
+*   [hypertable_detailed_size(hypertable)](https://docs.timescale.com/v2.0/api#hypertable_detailed_size):  
+The function has been renamed from `hypertable_relation_size(hypertable)`.  Further, if the hypertable is distributed, 
+it will return multiple rows, one per each of the hypertable’s data nodes.
+*   [hypertable_size(hypertable)](https://docs.timescale.com/v2.0/api#hypertable_size):  Returns a single 
+value giving the aggregated hypertable size, including both tables (chunks) and indexes.
+*   [chunks_detailed_size(hypertable)](https://docs.timescale.com/v2.0/api#chunks_detailed_size):  Returns 
+the size information about each of the chunks in a hypertable. On a distributed hypertable, this function 
+returns one row per data node that holds a copy of the chunk.
+*   [hypertable_index_size(index)](https://docs.timescale.com/v2.0/api#hypertable_index_size): Returns the 
+aggregate number of bytes corresponding to a hypertable index across all chunks.
+*   [approximate_row_count(relation)](https://docs.timescale.com/v2.0/api#approximate_row_count):  The function 
+has been renamed from `hypertable_approximate_row_count`, but can now also be called on non-hypertables.
 
-In previous versions of TimescaleDB, you could get size information for all hypertables in the `hypertable` view. In TimescaleDB 2.0, you can now instead combine the new `hypertables` view with size functions to achieve a similar result:
+In previous versions of TimescaleDB, you could get size information for all hypertables in the `hypertable` view. 
+In TimescaleDB 2.0, you can now instead combine the new `hypertables` view with size functions to achieve a similar result:
 
 
 ```SQL
@@ -106,13 +179,18 @@ SELECT hypertable_name, hypertable_size(hypertable_name::regclass) FROM timescal
  conditions      |      	253952
 ```
 
-# Continuous Aggregates
+# Continuous Aggregates [](caggs)
 
 Major changes have been made to Continuous Aggregates in TimescaleDB 2.0 to better clarify this feature.
 
-First, Continuous Aggregates have always been more closely aligned with Materialized Views in PostgreSQL. Therefore, creating a continuous aggregate now uses `CREATE MATERIALIZED VIEW`, rather than `CREATE VIEW`.
+First, Continuous Aggregates have always been more closely aligned with Materialized Views in PostgreSQL. Therefore, 
+creating a continuous aggregate now uses `CREATE MATERIALIZED VIEW`, rather than `CREATE VIEW`.
 
-Second, the continuous aggregate API now separates the explicit mechanism for updating a continuous aggregate, and the policy that automates the process of keeping a continuous aggregate up-to-date.  This change both simplifies the continuous aggregate API in TimescaleDB 2.0, provides more flexibility to users (especially when combined with user-defined actions and a newly-exposed API for scheduling jobs directly), and makes it consistent with other policy automation in TimescaleDB 2.0:
+Second, the continuous aggregate API now separates the explicit mechanism for updating a continuous aggregate, 
+and the policy that automates the process of keeping a continuous aggregate up-to-date.  This change both 
+simplifies the continuous aggregate API in TimescaleDB 2.0, provides more flexibility to users (especially when 
+combined with user-defined actions and a newly-exposed API for scheduling jobs directly), and makes it consistent 
+with other policy automation in TimescaleDB 2.0:
 
 Action API                    | Policy API for Automation
 ------------------------------|--------------------------
@@ -145,27 +223,51 @@ SELECT add_continuous_aggregate_policy(
   schedule_interval    => '1 hour');
 ```
 
-In the example above, `CREATE MATERIALIZED VIEW `creates a continuous aggregate without any automation yet associated with it.  Notice also that  `WITH NO DATA` is specified at the end. This prevents the view from materializing data at creation time, instead deferring the population of aggregated data until the policy runs as a background job or as part of a manual refresh. Therefore, we that users create continuous aggregates using the `WITH NO DATA` option, especially if a significant amount of historical data will be materialized.
+In the example above, `CREATE MATERIALIZED VIEW `creates a continuous aggregate without any automation yet 
+associated with it.  Notice also that  `WITH NO DATA` is specified at the end. This prevents the view from 
+materializing data at creation time, instead deferring the population of aggregated data until the policy runs 
+as a background job or as part of a manual refresh. Therefore, we that users create continuous aggregates 
+using the `WITH NO DATA` option, especially if a significant amount of historical data will be materialized.
 
-Once the Continuous Aggregate is created, calling `add_continuous_aggregate_policy` creates a continuous aggregate policy, which automatically materializes or refreshes the data following the schedule and rules provided. Inputs to the policy function include the continuous aggregate name, a refresh window, and a schedule interval.  The refresh window is specified by the start and end offsets, which are used to calculate a new refresh window every time the policy runs by subtracting the offsets from the current time (as normally returned by the function `now()`).
+Once the Continuous Aggregate is created, calling `add_continuous_aggregate_policy` creates a continuous 
+aggregate policy, which automatically materializes or refreshes the data following the schedule and rules 
+provided. Inputs to the policy function include the continuous aggregate name, a refresh window, and a 
+schedule interval.  The refresh window is specified by the start and end offsets, which are used to calculate 
+a new refresh window every time the policy runs by subtracting the offsets from the current time (as normally 
+returned by the function `now()`).
 
 
-## Understanding Continuous Aggregate Policies
+## Understanding Continuous Aggregate Policies [](cagg-policies)
 
 It is worth noting the way that “start_offset” and “end_offset” work as new data arrives and is added to the source Hypertables.
 
-The above example sets the refresh interval as between four weeks and two hours ago (start_offset and end_offset respectively). Therefore, if any late data arrives with timestamps within the last four weeks and is backfilled into the source hypertable, then the continuous aggregate view is updated with this old data the next time the policy executes. 
+The above example sets the refresh interval as between four weeks and two hours ago (start_offset and end_offset 
+respectively). Therefore, if any late data arrives with timestamps within the last four weeks and is backfilled 
+into the source hypertable, then the continuous aggregate view is updated with this old data the next time the policy executes. 
 
-This policy will, in the worst case, materialize the whole window every time it runs if data at least four weeks old continues to arrive and be inserted into the source Hypertables.  However, since a continuous aggregate tracks changes since the last refresh, it will in most cases materialize a subset of the window that corresponds to the data that has actually changed. 
+This policy will, in the worst case, materialize the whole window every time it runs if data at least four weeks 
+old continues to arrive and be inserted into the source Hypertables.  However, since a continuous aggregate tracks 
+changes since the last refresh, it will in most cases materialize a subset of the window that corresponds to the 
+data that has actually changed. 
 
-In this example, data backfilled more than 4 weeks ago is not rematerialized, nor does the continuous aggregate include data less than 2 hours old.  However, _querying the continuous aggregate view can still return aggregates about the latest data, and not just aggregated data more than 2 hours old, based on support for [real-time aggregation](https://docs.timescale.com/latest/using-timescaledb/continuous-aggregates#real-time-aggregates)_, specified as before with the `timescaledb.materialized_only=false` parameter. Real-time aggregates are still the default setting unless otherwise specified.
+In this example, data backfilled more than 4 weeks ago is not rematerialized, nor does the continuous aggregate 
+include data less than 2 hours old.  However, _querying the continuous aggregate view can still return aggregates 
+about the latest data, and not just aggregated data more than 2 hours old, based on support for 
+[real-time aggregation](https://docs.timescale.com/latest/using-timescaledb/continuous-aggregates#real-time-aggregates)_, 
+specified as before with the `timescaledb.materialized_only=false` parameter. Real-time aggregates are still the default 
+setting unless otherwise specified.
 
-Finally, it is recommended that the `end_offset` lags the current time by at least one `time_bucket `as defined in the aggregate SQL, otherwise it might affect performance when inserting new data, which usually is written to what would be the latest bucket.  In TimescaleDB 1.x, the `refresh_lag` parameter was used for a similar purpose, but we found that  using it correctly was more difficult to understand.
+Finally, it is recommended that the `end_offset` lags the current time by at least one `time_bucket `as defined 
+in the aggregate SQL, otherwise it might affect performance when inserting new data, which usually is written to 
+what would be the latest bucket.  In TimescaleDB 1.x, the `refresh_lag` parameter was used for a similar purpose, 
+but we found that  using it correctly was more difficult to understand.
 
 
-## Manually refreshing regions of continuous aggregates
+## Manually refreshing regions of continuous aggregates [](cagg-refresh)
 
-TimescaleDB 2.0 removes support for `REFRESH MATERIALIZED VIEW` in favor of the new, more flexible function, [refresh_continuous_aggregate](https://docs.timescale.com/v2.0/api#refresh_continuous_aggregate), which enables a user to refresh a specific window in a continuous aggregate:
+TimescaleDB 2.0 removes support for `REFRESH MATERIALIZED VIEW` in favor of the new, more flexible function, 
+[refresh_continuous_aggregate](https://docs.timescale.com/v2.0/api#refresh_continuous_aggregate), which enables 
+a user to refresh a specific window in a continuous aggregate:
 
 
 ```SQL
@@ -175,116 +277,192 @@ CALL refresh_continuous_aggregate(
   window_end           => '2020-05-03');
 ```
 
-Users can use this command explicitly; a typical use of this command is to manually refresh historical data while creating a continuous aggregate policy to aggregate new data. It is even possible to build custom continuous aggregation policies using this function within the new user-defined action framework which are then scheduled via `add_job`. 
+Users can use this command explicitly; a typical use of this command is to manually refresh historical data 
+while creating a continuous aggregate policy to aggregate new data. It is even possible to build custom 
+continuous aggregation policies using this function within the new user-defined action framework which are 
+then scheduled via `add_job`. 
 
-Note that` refresh_continuous_aggregate` only recomputes the aggregated time buckets that completely fall inside the given refresh window boundaries and are in a region that has seen changes in the underlying hypertable. Thus, if no changes have occurred in the underlying source data (that is, no data has been backfilled to the region or no updates to existing data have been made), no materialization will be performed either over that region. This behavior is similar to the continuous aggregate policy and ensures more efficient operation.
+Note that` refresh_continuous_aggregate` only recomputes the aggregated time buckets that completely fall 
+inside the given refresh window boundaries and are in a region that has seen changes in the underlying hypertable. 
+Thus, if no changes have occurred in the underlying source data (that is, no data has been backfilled to the 
+region or no updates to existing data have been made), no materialization will be performed either over that 
+region. This behavior is similar to the continuous aggregate policy and ensures more efficient operation.
 
 
 ## Using data retention and continuous aggregates together [](retention-and-caggs)
 
-With greater power and flexibility also comes a greater responsibility to understand how features interact. Specifically, users should understand the interactions between data retention policy settings and continuous aggregate settings. 
+With greater power and flexibility also comes a greater responsibility to understand how features interact. Specifically, 
+users should understand the interactions between data retention policy settings and continuous aggregate settings. 
 
-Before starting the upgrade to TimescaleDB 2.0, **we highly recommend checking the database log for errors related to failed retention policies that were occurring in TimescaleDB 1.x** and then either remove them or update them to be compatible with existing continuous aggregates. Any remaining retention policies that are still incompatible with the `ignore_invalidation_older_than `setting will automatically be disabled with a notice during the upgrade.
+Before starting the upgrade to TimescaleDB 2.0, **we highly recommend checking the database log for errors related 
+to failed retention policies that were occurring in TimescaleDB 1.x** and then either remove them or update them t
+o be compatible with existing continuous aggregates. Any remaining retention policies that are still incompatible 
+with the `ignore_invalidation_older_than `setting will automatically be disabled with a notice during the upgrade.
 
-As an example, if a data retention policy on a hypertable is set for `drop_after => '4 weeks'`, then the policy associated with a continuous aggregate on that same hypertable should have a `start_offset` less than or equal to 4 weeks.  Similarly, any manual call to `refresh_continuous_aggregate` should likely specify a `window_start` that’s also less than the date from 4 weeks ago. 
+As an example, if a data retention policy on a hypertable is set for `drop_after => '4 weeks'`, then the policy 
+associated with a continuous aggregate on that same hypertable should have a `start_offset` less than or equal 
+to 4 weeks.  Similarly, any manual call to `refresh_continuous_aggregate` should likely specify a `window_start` 
+that’s also less than the date from 4 weeks ago. 
 
-If not understood properly, users could overwrite existing aggregated data in continuous aggregates with empty data by recomputing data over a now-dropped time window of data, not likely the result a user was expecting. Instead, users seeking to keep only a certain time window of data in their continuous aggregate view should create a data retention policy on the continuous aggregate.
+If not understood properly, users could overwrite existing aggregated data in continuous aggregates with empty 
+data by recomputing data over a now-dropped time window of data, not likely the result a user was expecting. 
+Instead, users seeking to keep only a certain time window of data in their continuous aggregate view should 
+create a data retention policy on the continuous aggregate.
 
 **This differs significantly from how TimescaleDB 1.x handled conflicts between retention policies and continuous aggregates.**
 
-Previously, if the continuous aggregation setting `ignore_invalidation_older_than` overlapped with data that would be dropped by a retention policy, the retention policy would silently fail.  Making the retention policy work again required users to modify settings in either the retention policy or the continuous aggregate, and even then some data wasn’t always materialized as expected. 
+Previously, if the continuous aggregation setting `ignore_invalidation_older_than` overlapped with data that would 
+be dropped by a retention policy, the retention policy would silently fail.  Making the retention policy work again 
+required users to modify settings in either the retention policy or the continuous aggregate, and even then some 
+data wasn’t always materialized as expected. 
 
-After upgrading to TimescaleDB 2.0, **retention policies will no longer fail due to incompatibilities with continuous aggregates** and users have to ensure that retention and continuous aggregate policies have the desired interplay. 
+After upgrading to TimescaleDB 2.0, **retention policies will no longer fail due to incompatibilities with 
+continuous aggregates** and users have to ensure that retention and continuous aggregate policies have the 
+desired interplay. 
 
-## Differences in the handling of backfill on continuous aggregates
+## Differences in the handling of backfill on continuous aggregates [](cagg-backfill)
 
-In TimescaleDB 1.x, data that was backfilled into hypertables wasn’t handled optimally; modification of any hypertable data, regardless of how old, would cause the continuous aggregate materializer job to restart from the point of the earliest backfill and then it would materialize from that point forward. Unfortunately, this could also cause the materializer to get “stuck”, since the background job only processed a limited amount of data per run, as governed by the `max_interval_per_job` setting. When this happened, one job run could potentially force the next job to start all over again. 
+In TimescaleDB 1.x, data that was backfilled into hypertables wasn’t handled optimally; modification of 
+any hypertable data, regardless of how old, would cause the continuous aggregate materializer job to restart 
+from the point of the earliest backfill and then it would materialize from that point forward. Unfortunately, 
+this could also cause the materializer to get “stuck”, since the background job only processed a limited 
+amount of data per run, as governed by the `max_interval_per_job` setting. When this happened, one job run 
+could potentially force the next job to start all over again. 
 
-To prevent this, the `ignore_invalidation_older_than` setting could be used to ignore backfill data older than a specified interval (e.g., ignore backfill older than 1 week), preventing the materializer from restarting if hypertable data was modified beyond this interval boundary. However, this would also stop TimescalDB 1.x from tracking changes in the underlying data beyond the `ignore_invalidation_older_than` threshold too. This meant that it was not possible to revert this setting later to a larger interval (e.g., 1 month) without potentially having a mismatch between the raw data and the aggregated data in the continuous aggregate.
+To prevent this, the `ignore_invalidation_older_than` setting could be used to ignore backfill data older than 
+a specified interval (e.g., ignore backfill older than 1 week), preventing the materializer from restarting if 
+hypertable data was modified beyond this interval boundary. However, this would also stop TimescalDB 1.x from 
+tracking changes in the underlying data beyond the `ignore_invalidation_older_than` threshold too. This meant 
+that it was not possible to revert this setting later to a larger interval (e.g., 1 month) without potentially 
+having a mismatch between the raw data and the aggregated data in the continuous aggregate.
 
-In contrast, TimescaleDB 2.0 never stops tracking backfill, and to avoid materializing too much historical data, one should simply use a refresh window that does not include that region of data. The backfilled region can always be refreshed at a later time, either manually or via a policy.
+In contrast, TimescaleDB 2.0 never stops tracking backfill, and to avoid materializing too much historical data, 
+one should simply use a refresh window that does not include that region of data. The backfilled region can 
+always be refreshed at a later time, either manually or via a policy.
 
-To ensure that previously ignored backfill can be refreshed after the upgrade to TimescaleDB 2.0, the upgrade process will mark the region older than the `ignore_invalidation_older_than` threshold as “requiring refresh”. This allows a manual refresh to bring a continuous aggregate up-to-date with the underlying source data. If the `ignore_invalidation_older_than` threshold was reset to a larger interval at some point, we recommend setting it back to the smaller interval prior to upgrading to ensure that all the backfill can be refreshed, if one so desires. 
+To ensure that previously ignored backfill can be refreshed after the upgrade to TimescaleDB 2.0, the upgrade 
+process will mark the region older than the `ignore_invalidation_older_than` threshold as “requiring refresh”. 
+This allows a manual refresh to bring a continuous aggregate up-to-date with the underlying source data. If 
+the `ignore_invalidation_older_than` threshold was reset to a larger interval at some point, we recommend 
+setting it back to the smaller interval prior to upgrading to ensure that all the backfill can be refreshed, 
+if one so desires. 
 
-Note again, however, that if backfill was previously ignored due to a retention policy on the underlying hypertable, a manual refresh of older data into a continuous aggregate could remove data when hypertable chunks have been dropped due to a data retention policy as discussed in the previous section.
+Note again, however, that if backfill was previously ignored due to a retention policy on the underlying hypertable, 
+a manual refresh of older data into a continuous aggregate could remove data when hypertable chunks have been 
+dropped due to a data retention policy as discussed in the previous section.
 
-## Viewing information about continuous aggregates
+## Viewing information about continuous aggregates [](cagg-information-views)
 
 In TimescaleDB 2.0, views surrounding continuous aggregates (and other policies) have been simplified and generalized.
 
 ### Changes and Additions
-*   [timescaledb_information.continuous_aggregates](https://docs.timescale.com/v2.0/api#timescaledb_information-continuous_aggregate): now provides information related to the materialized view, which includes the view name and owner, the real time aggregation flag, the materialization and the view definition (the select statement defining the view)
-*   [timescaledb_information.jobs](https://docs.timescale.com/v2.0/api#timescaledb_information-jobs): displays information for all policies including continuous aggregates  
-*   [Timescaledb_information.job_stats](https://docs.timescale.com/v2.0/api#timescaledb_information-jobs_stats): displays job statistics related to all jobs
+*   [timescaledb_information.continuous_aggregates](https://docs.timescale.com/v2.0/api#timescaledb_information-continuous_aggregate): 
+now provides information related to the materialized view, which includes the view name and owner, the real 
+time aggregation flag, the materialization and the view definition (the select statement defining the view)
+*   [timescaledb_information.jobs](https://docs.timescale.com/v2.0/api#timescaledb_information-jobs): displays information for 
+all policies including continuous aggregates  
+*   [Timescaledb_information.job_stats](https://docs.timescale.com/v2.0/api#timescaledb_information-jobs_stats): displays job 
+statistics related to all jobs
 
 ### Removed
 * [timescaledb_information.continuous_aggregate_stats](https://docs.timescale.com/v1.7/api#timescaledb_information-continuous_aggregate_stats): Removed in favor of the `job_stats` view mentioned above.
 
 ## Updating existing continuous aggregates [](updating-continuous-aggregates)
 
-If you have existing continuous aggregates and you update your database to TimescaleDB 2.0, the update scripts will automatically reconfigure your continuous aggregates to use the new framework.
+If you have existing continuous aggregates and you update your database to TimescaleDB 2.0, the update scripts 
+will automatically reconfigure your continuous aggregates to use the new framework.
 
 In particular, the update process should:
 
 *   Maintain the same view schema, name, owner, and view definition as before, as well as the setting for `materialized_only`.
-*   Schedule the refresh to run at the same interval as before (although the parameter is now named `schedule_interval` rather than `refresh_interval`).
+*   Schedule the refresh to run at the same interval as before (although the parameter is now named `schedule_interval` r
+ather than `refresh_interval`).
 *   Automatically configure `start_offset` to the same offset as specified by the old `ignore_invalidation_older_than` setting. 
 *   Automatically configure `end_offset` to have an offset from `now()` equivalent to  the old `refresh_lag` setting.
 *   Mark all the data older than the interval `ignore_invalidation_older_than` as out-of-date, so that it can be refreshed.
-*   Disable any retention policies that are failing due to being incompatible with the current setting of `ignore_invalidation_older_than` on a continuous aggregate (as described above). Disabled policies will remain post upgrade, but will not be scheduled to run (`scheduled=false `in` timescaledb_information.jobs`). If failing policies were to be migrated to 2.0 they would start to work again, but likely with unintended consequences. Therefore, any retention policies that are disabled post update should have their settings carefully reviewed before being enabled again.
+*   Disable any retention policies that are failing due to being incompatible with the current setting of 
+`ignore_invalidation_older_than` on a continuous aggregate (as described above). Disabled policies will remain post 
+upgrade, but will not be scheduled to run (`scheduled=false `in` timescaledb_information.jobs`). If failing policies 
+were to be migrated to 2.0 they would start to work again, but likely with unintended consequences. Therefore, any 
+retention policies that are disabled post update should have their settings carefully reviewed before being enabled again.
 
 You can validate these in the proper informational views, given above.
 
-
-# Other Superficial API Changes
+# Other Superficial API Changes [](other-changes)
 
 Other minor changes were made to various APIs for greater understandability and consistency, including in the following areas.
 
-## Data Retention
+## Data Retention [](data-retention)
 
 ### Changes and Additions
-*   [drop_chunks](https://docs.timescale.com/v2.0/api#drop_chunks): This function now requires specifying a hypertable or continuous aggregate as the first argument, and does not allow dropping chunks across all hypertables in a database.  Additionally, the arguments `cascade` and `cascade_to_materializations` were removed (and behave as if the arguments were set to `false` in earlier versions). In TimescaleDB 2.0, we instead recommend creating a separate retention policy on each continuous aggregate. 
-*   [add_retention_policy](https://docs.timescale.com/v2.0/api#add_retention_policy), [remove_retention_policy](https://docs.timescale.com/v2.0/api#remove_retention_policy):  Creating (or removing) a data retention policy now have explicit functions. Additionally, the arguments `cascade` and `cascade_to_materializations` were removed (and behave as if the arguments were set to `false` in earlier versions).
-*   [timescaledb_information.jobs](https://docs.timescale.com/v2.0/api#jobs): General information about data retention policies are now available in the main jobs view
+*   [drop_chunks](https://docs.timescale.com/v2.0/api#drop_chunks): This function now requires specifying a 
+hypertable or continuous aggregate as the first argument, and does not allow dropping chunks across all hypertables 
+in a database.  Additionally, the arguments `cascade` and `cascade_to_materializations` were removed (and behave as 
+if the arguments were set to `false` in earlier versions). In TimescaleDB 2.0, we instead recommend creating a 
+separate retention policy on each continuous aggregate. 
+*   [add_retention_policy](https://docs.timescale.com/v2.0/api#add_retention_policy), [remove_retention_policy](https://docs.timescale.com/v2.0/api#remove_retention_policy):  
+Creating (or removing) a data retention policy now have explicit functions. Additionally, the arguments `cascade` 
+and `cascade_to_materializations` were removed (and behave as if the arguments were set to `false` in earlier versions).
+*   [timescaledb_information.jobs](https://docs.timescale.com/v2.0/api#jobs): General information about data retention 
+policies are now available in the main jobs view
 
 ### Removed
-*   [add_drop_chunks_policy](https://docs.timescale.com/v1.7/api#add_drop_chunks_policy): removed in favor of the explicit functions above
-*   [timescaledb_information.drop_chunks_policies](https://docs.timescale.com/v1.7/api#timescaledb_information-drop_chunks_policies) view has been removed in favor of the more general jobs view.
+*   [add_drop_chunks_policy](https://docs.timescale.com/v1.7/api#add_drop_chunks_policy): removed in favor of the 
+explicit functions above
+*   [timescaledb_information.drop_chunks_policies](https://docs.timescale.com/v1.7/api#timescaledb_information-drop_chunks_policies):
+ view has been removed in favor of the more general jobs view.
 
 
-## Compression
+## Compression [](compression)
 
 ### Changes and Additions
-*   [add_compression_policy](https://docs.timescale.com/v2.0/api#add_compression_policy), [remove_compression_policy](https://docs.timescale.com/v2.0/api#remove_compression_policy):  Creating (or removing) a compression policy now have explicit functions
-*   [hypertable_compression_stats(hypertable)](https://docs.timescale.com/v2.0/api#hypertable_compression_stats): The function  returns statistics only for hypertables with compression enabled
-*   [chunk_compression_stats(hypertable)](https://docs.timescale.com/v2.0/api#chunk_compression_stats):  The function returns information about currently compressed chunks
-*   [timescaledb_information.compression_settings](https://docs.timescale.com/v2.0/api#timescaledb_information-compression_settings): This new view gives information about the compression settings on hypertables
-*   [timescaledb_information.jobs](https://docs.timescale.com/v2.0/api#timescaledb_information-jobs): General information about compression policies are now available in the main jobs view
+*   [add_compression_policy](https://docs.timescale.com/v2.0/api#add_compression_policy), [remove_compression_policy](https://docs.timescale.com/v2.0/api#remove_compression_policy):  
+Creating (or removing) a compression policy now have explicit functions
+*   [hypertable_compression_stats(hypertable)](https://docs.timescale.com/v2.0/api#hypertable_compression_stats): The function 
+ returns statistics only for hypertables with compression enabled
+*   [chunk_compression_stats(hypertable)](https://docs.timescale.com/v2.0/api#chunk_compression_stats):  The function returns 
+information about currently compressed chunks
+*   [timescaledb_information.compression_settings](https://docs.timescale.com/v2.0/api#timescaledb_information-compression_settings)
+: This new view gives information about the compression settings on hypertables
+*   [timescaledb_information.jobs](https://docs.timescale.com/v2.0/api#timescaledb_information-jobs): General information about 
+compression policies are now available in the main jobs view
 
 ### Removed
-* [add_compress_chunk_policy](https://docs.timescale.com/v1.7/api#add_compress_chunks_policy): removed in favor of the explicit functions above
-* [timescaledb_information.compressed_hypertable_stats](https://docs.timescale.com/v1.7/api#timescaledb_information-compressed_hypertable_stats): removed in favor of the new `hypertable_compression_stats(hypertable)` function linked above
-* [timescaledb_information.compressed_chunk_stats](https://docs.timescale.com/v1.7/api#timescaledb_information-compressed_chunk_stats): removed in favor of the new `chunk_compression_stats(hypertable)` function linked above
+* [add_compress_chunk_policy](https://docs.timescale.com/v1.7/api#add_compress_chunks_policy): removed in favor of the 
+explicit functions above
+* [timescaledb_information.compressed_hypertable_stats](https://docs.timescale.com/v1.7/api#timescaledb_information-compressed_hypertable_stats): 
+removed in favor of the new `hypertable_compression_stats(hypertable)` function linked above
+* [timescaledb_information.compressed_chunk_stats](https://docs.timescale.com/v1.7/api#timescaledb_information-compressed_chunk_stats): 
+removed in favor of the new `chunk_compression_stats(hypertable)` function linked above
 
-## Managing policies and other jobs
+## Managing policies and other jobs [](jobs)
 
-TimescaleDB 2.0 introduces user-defined actions and creates a more unified jobs API. Now, jobs created by the TimescaleDB policies and for user-defined actions can be managed and viewed through a single API.
-
-
+TimescaleDB 2.0 introduces user-defined actions and creates a more unified jobs API. Now, jobs created by the 
+TimescaleDB policies and for user-defined actions can be managed and viewed through a single API.
 
 *   `add_job:` Adds a new user-defined action to the job scheduling framework.
-*   `alter_job:` Changes settings for existing jobs.  Renamed from `alter_job_schedule` in previous versions,  it introduces additional settings, including  `scheduled` to pause and resume jobs, and `config` to change policy or action-specific settings.
+*   `alter_job:` Changes settings for existing jobs.  Renamed from `alter_job_schedule` in previous versions,  it 
+introduces additional settings, including  `scheduled` to pause and resume jobs, and `config` to change policy 
+or action-specific settings.
 *   `run_job`: Manually executes a job immediately and in the foreground.
-*   `delete_job`: Removes the job from the scheduler.  This is equivalent to functions that remove policies for built-in actions (e.g., `remove_retention_policy`). 
+*   `delete_job`: Removes the job from the scheduler.  This is equivalent to functions that remove policies for 
+built-in actions (e.g., `remove_retention_policy`). 
 *   `timescaledb_information.jobs`:  The new view provides all job settings available, and it replaces all policy-specific views.
 *   `timescaledb_information.job_stats`:  The view presents statistics of executing jobs for policies and actions.
 
 
-## License information
+## License information [](license-changes)
 
-In TimescaleDB 2.0, all features which had been classified previously as “enterprise” have become “community” features and are available for free under the Timescale License.  As such, the need for an “enterprise license” to unlock any features has been removed; all features are available either under the community Timescale License or under the open-source Apache-2 License. [This blog post](https://blog.timescale.com/blog/building-open-source-business-in-cloud-era-v2/) explains the changes. The following changes were made to license API:
+In TimescaleDB 2.0, all features which had been classified previously as “enterprise” have become “community” features 
+and are available for free under the Timescale License.  As such, the need for an “enterprise license” to unlock any 
+features has been removed; all features are available either under the community Timescale License or under the 
+open-source Apache-2 License. [This blog post](https://blog.timescale.com/blog/building-open-source-business-in-cloud-era-v2/) 
+explains the changes. The following changes were made to license API:
 
-
-
-*   [timescaledb_information.license](https://docs.timescale.com/v1.7/api#timescaledb_information-license):  This view has been removed, as it primarily provided information on the enterprise license key’s expiration date, which is no longer applicable. The current license used by the extension can instead be viewed in the GUC below.
-*   `timescaledb.license`: This GUC value (which replaces the former [timescaledb.license_key](https://docs.timescale.com/latest/api#timescaledb_license-key) GUC) can take the value `timescale` or `apache`. It can be set only at startup (in the postgresql.conf configuration file or on the server command line), and allows limiting access to certain features by license. For example, setting the license to `apache` allows access to only Apache-2 licensed features.
+*   [timescaledb_information.license](https://docs.timescale.com/v1.7/api#timescaledb_information-license):  This view 
+has been removed, as it primarily provided information on the enterprise license key’s expiration date, which is no 
+longer applicable. The current license used by the extension can instead be viewed in the GUC below.
+*   `timescaledb.license`: This GUC value (which replaces the former [timescaledb.license_key](https://docs.timescale.com/latest/api#timescaledb_license-key) GUC) 
+can take the value `timescale` or `apache`. It can be set only at startup (in the postgresql.conf configuration file 
+or on the server command line), and allows limiting access to certain features by license. For example, setting the l
+icense to `apache` allows access to only Apache-2 licensed features.

--- a/getting-started/setup-multi-node.md
+++ b/getting-started/setup-multi-node.md
@@ -1,8 +1,8 @@
 # Setting up Multi-Node TimescaleDB
 
->:WARNING: Distributed hypertables are currently in BETA and
-are not yet meant for production use. For more information, please
-[contact us][contact] or join the #multinode-beta channel in our 
+>:WARNING: Distributed hypertables and [multi-node capabilities][multi-node-basic]
+are currently in BETA. This feature is not meant for production use. For more information,
+please [contact us][contact] or join the #multinode channel in our 
 [community Slack][slack].
 
 Data nodes together with an *access node* constitute the

--- a/introduction/architecture.md
+++ b/introduction/architecture.md
@@ -140,9 +140,9 @@ For more on the motivation and design of TimescaleDB, please see our
 
 ## Distributed Hypertables [](distributed-hypertables)
 
->:WARNING: Distributed hypertables are currently in BETA.
-This feature is not meant for production use. For more information,
-please [contact us][contact] or join the #multinode-beta channel in our 
+>:WARNING: Distributed hypertables and [multi-node capabilities][multi-node-basic]
+are currently in BETA. This feature is not meant for production use. For more information,
+please [contact us][contact] or join the #multinode channel in our 
 [community Slack][slack].
 
 TimescaleDB supports distributing hypertables across multiple nodes
@@ -227,3 +227,4 @@ can be changed, the column on which the data is partitioned can not be changed.
 [contact]: https://www.timescale.com/contact
 [slack]: https://slack.timescale.com/
 [distributed-hypertable-limitations]: /using-timescaledb/limitations#distributed-hypertable-limitations
+[multi-node-basic]: /getting-started/setup-multi-node-basic

--- a/page-index/page-index.js
+++ b/page-index/page-index.js
@@ -51,19 +51,6 @@ const pageIndex = [
                 component: "InstallationPage",
                 children: [
                     {
-                        Title: "Timescale Cloud",
-                        type: DIRECTORY,
-                        href: "timescale-cloud",
-                        src: "//assets.iobeam.com/images/docs/timescale_cloud_logo.svg",
-                        children: [
-                            {
-                                Title: "Timescale Cloud",
-                                type: NON_MENU_PAGE,
-                                options: {pg_version: []},
-                                href: "installation-timescale-cloud"
-                            }
-                       ]
-                    }, {
                         Title: "Docker",
                         type: DIRECTORY,
                         href: "docker",
@@ -121,50 +108,6 @@ const pageIndex = [
                                 Title: "Source",
                                 type: NON_MENU_PAGE,
                                 href: "installation-source"
-                            }
-                        ]
-                    }, {
-                        Title: "Windows",
-                        type: DIRECTORY,
-                        href: "windows",
-                        src: "//assets.iobeam.com/images/docs/Windows_logo_-_2012.svg",
-                        children: [
-                            {
-                                Title: "Installer (.zip)",
-                                type: NON_MENU_PAGE,
-                                href: "installation-windows"
-                            }, {
-                                Title: "Source",
-                                type: NON_MENU_PAGE,
-                                href: "installation-source-windows"
-                            }
-                        ]
-                    }, {
-                        Title: "MacOS",
-                        type: DIRECTORY,
-                        href: "macos",
-                        src: "//assets.iobeam.com/images/docs/Apple_logo_black.svg",
-                        children: [
-                            {
-                                Title: "Homebrew",
-                                type: NON_MENU_PAGE,
-                                href: "installation-homebrew"
-                            }, {
-                                Title: "Source",
-                                type: NON_MENU_PAGE,
-                                href: "installation-source"
-                            }
-                        ]
-                    }, {
-                        Title: "AMI",
-                        type: DIRECTORY,
-                        href: "ami",
-                        src: "//assets.iobeam.com/images/docs/aws_logo.svg",
-                        children: [
-                            {
-                                Title: "Amazon AMI (Ubuntu)",
-                                type: NON_MENU_PAGE,
-                                href: "installation-ubuntu-ami"
                             }
                         ]
                     }
@@ -495,10 +438,6 @@ const pageIndex = [
                 type: PAGE,
                 href: "tooling"
             }, {
-                Title: "Update software",
-                type: PAGE,
-                href: "update-db"
-            }, {
                 Title: "Telemetry",
                 type: PAGE,
                 href: "telemetry"
@@ -695,7 +634,7 @@ const pageIndex = [
             }, {
                 type: HIDDEN_REDIRECT,
                 href: "update-db",
-                to: "/using-timescaledb/update-db"
+                to: "/update-timescaledb"
             }, {
                 type: HIDDEN_REDIRECT,
                 href: "data-retention",
@@ -732,8 +671,35 @@ const pageIndex = [
     }, {
         Title: "Release Notes",
         type: PAGE,
-        href: "release-notes"
+        href: "release-notes",
+        children: [
+            {
+                Title: "Changes in TimescaleDB 2.0",
+                type: PAGE,
+                href: "changes-in-timescaledb-2"
+            }
+        ]
     }, {
+        Title: "Update TimescaleDB",
+        type: PAGE,
+        href: "update-timescaledb",
+        children: [
+            {
+                Title: "Updating TimescaleDB from 1.x to 2.0",
+                type: PAGE,
+                href: "update-tsdb-2"
+            }, {
+                Title: "Updating Docker",
+                type: PAGE,
+                href: "update-docker"
+            }, {
+                Title: "Upgrading PostgreSQL",
+                type: PAGE,
+                href: "upgrade-pg"
+            }
+        ]
+    },
+     {
         Title: "GitHub",
         type: LINK,
         href: "https://github.com/timescale/timescaledb"

--- a/release-notes.md
+++ b/release-notes.md
@@ -15,11 +15,11 @@ can view active developments on GitHub at any time.
 The team is actively working on the multi-node version
 of TimescaleDB which is currently in beta. You can read more about our
 architecture and design for distributed hypertables
-[here](https://docs.timescale.com/beta-v2.0.0/introduction/architecture#distributed-hypertables).
+[here](https://docs.timescale.com/v2.0/introduction/architecture#distributed-hypertables).
 To test out the beta version for yourself, join our #multinode-beta channel on
 [community slack](https://slack.timescale.com/) for installation details and
 follow these [setup
-instructions](https://docs.timescale.com/beta-v2.0.0/getting-started/setup-multi-node).
+instructions](https://docs.timescale.com/v2.0/getting-started/setup-multi-node).
 
 Currently, we expect this major feature to be released
 in the second half 2020, and we will share more information once
@@ -27,6 +27,14 @@ it's available.
 
 The 2.0 release will also include some API changes to informational views,
 features, and other capabilities to make TimescaleDB easier to use and manage.
+
+
+>:TIP:TimescaleDB 2.0 is currently available as a release candidate and we encourage
+>users to upgrade in testing environments to gain experience and provide feedback on 
+>new and updated features.
+>
+>See [Changes in TimescaleDB 2.0](https://docs.timescale.com/v2.0/release-notes/changes-in-timescaledb-2) for more
+>information and links to installation instructions
 
 ## Release Notes
 

--- a/release-notes.md
+++ b/release-notes.md
@@ -16,7 +16,7 @@ The team is actively working on the multi-node version
 of TimescaleDB which is currently in beta. You can read more about our
 architecture and design for distributed hypertables
 [here](https://docs.timescale.com/v2.0/introduction/architecture#distributed-hypertables).
-To test out the beta version for yourself, join our #multinode-beta channel on
+To test out the beta version for yourself, join our #multinode channel on
 [community slack](https://slack.timescale.com/) for installation details and
 follow these [setup
 instructions](https://docs.timescale.com/v2.0/getting-started/setup-multi-node).

--- a/tutorials/clustering.md
+++ b/tutorials/clustering.md
@@ -1,8 +1,8 @@
 # Tutorial: Scaling out TimescaleDB
 
->:WARNING: Distributed hypertables are currently in BETA and
-are not yet meant for production use. For more information, please
-[contact us][contact] or join the #multinode-beta channel in our 
+>:WARNING: Distributed hypertables and [multi-node capabilities][multi-node-basic]
+are currently in BETA. This feature is not meant for production use. For more information,
+please [contact us][contact] or join the #multinode channel in our 
 [community Slack][slack].
 
 TimescaleDB can be run in a multi-node setup, with one primary access node distributing

--- a/update-timescaledb.md
+++ b/update-timescaledb.md
@@ -1,11 +1,15 @@
 # Updating TimescaleDB versions [](update)
 
 This section describes how to upgrade between different versions of
-TimescaleDB. TimescaleDB supports **in-place updates**:
+TimescaleDB. TimescaleDB supports **in-place updates only**:
 you don't need to dump and restore your data, and versions are published with
 automated migration scripts that convert any internal state if necessary.
 
-### TimescaleDB Release Compatability
+>:WARNING: There is currently no automated way to downgrade to an earlier release of TimescaleDB without setting up 
+>a new instance of PostgreSQL with a previous release of TimescaleDB and then using `pg_restore`
+>from a backup.
+
+### TimescaleDB Release Compatibility [](compatibility)
 
 TimescaleDB currently has two major release versions listed below. Please ensure that your version of
 PostgreSQL is supported with the extension version you want to install or update.
@@ -24,9 +28,9 @@ your current upgrade path.
 
 **TimescaleDB 2.0**: [Updating TimescaleDB from 1.x to 2.0-RC1+][update-tsdb-2]
 
-**TimescaleDB 2.0 on Docker**: [Update TimescaleDB on Docker from 1.7.4 to 2.0-RC1+][update-docker]
+**TimescaleDB 2.0 on Docker**: [Updating TimescaleDB on Docker from 1.7.4 to 2.0-RC1+][update-docker]
 
-**TimescaleDB 1.x**: [Update TimescaleDB 1.x to 1.7.4][update-tsdb-1]
+**TimescaleDB 1.x**: [Updating TimescaleDB 1.x to 1.7.4][update-tsdb-1]
 
 
 [upgrade-pg]: /update-timescaledb/upgrade-pg

--- a/update-timescaledb.md
+++ b/update-timescaledb.md
@@ -1,0 +1,35 @@
+# Updating TimescaleDB versions [](update)
+
+This section describes how to upgrade between different versions of
+TimescaleDB. TimescaleDB supports **in-place updates**:
+you don't need to dump and restore your data, and versions are published with
+automated migration scripts that convert any internal state if necessary.
+
+### TimescaleDB Release Compatability
+
+TimescaleDB currently has two major release versions listed below. Please ensure that your version of
+PostgreSQL is supported with the extension version you want to install or update.
+
+ TimescaleDB Release |   Supported PostgreSQL Release
+ --------------------|-------------------------------
+ 1.7.4               | 9.6, 10, 11, 12
+ 2.0-RC1+            | 11, 12
+
+>:TIP:If you need to upgrade PostgreSQL first, please see [our documentation][upgrade-pg].
+
+### Upgrade TimescaleDB
+
+To upgrade an existing TimescaleDB instance, follow the documentation below based on
+your current upgrade path.
+
+**TimescaleDB 2.0**: [Updating TimescaleDB from 1.x to 2.0-RC1+][update-tsdb-2]
+
+**TimescaleDB 2.0 on Docker**: [Update TimescaleDB on Docker from 1.7.4 to 2.0-RC1+][update-docker]
+
+**TimescaleDB 1.x**: [Update TimescaleDB 1.x to 1.7.4][update-tsdb-1]
+
+
+[upgrade-pg]: /update-timescaledb/upgrade-pg
+[update-tsdb-1]: https://docs.timescale.com/v1.7/update-timescaledb/update-tsdb-1
+[update-tsdb-2]: /update-timescaledb/update-tsdb-2
+[update-docker]: /update-timescaledb/update-docker

--- a/update-timescaledb/update-docker.md
+++ b/update-timescaledb/update-docker.md
@@ -1,0 +1,90 @@
+# Updating a TimescaleDB Docker installation
+
+As a more concrete example, the following steps should be taken with a docker
+installation to upgrade to the latest TimescaleDB version, while
+retaining data across the updates.
+
+The following instructions assume that your docker instance is named
+`timescaledb`. If not, replace this name with the one you use in the subsequent
+commands.
+
+#### Step 1: Pull new image [](update-docker-1)
+Install the current TimescaleDB 2.0-RC2 image:
+
+```bash
+docker pull timescale/timescaledb:2.0.0-rc2-pg12
+```
+>:TIP: If you are using PostgreSQL 11 images, use the tag `2.0.0-rc2-pg11`.
+
+#### Step 2: Determine mount point used by old container [](update-docker-2)
+As you'll want to restart the new docker image pointing to a mount point
+that contains the previous version's data, we first need to determine
+the current mount point.
+
+There are two types of mounts. To find which mount type your old container is
+using you can run the following command:
+```bash
+docker inspect timescaledb --format='{{range .Mounts }}{{.Type}}{{end}}'
+```
+This command will return either `volume` or `bind`, corresponding
+to the two options below.
+
+1. [Volumes][volumes] -- to get the current volume name use:
+```bash
+$ docker inspect timescaledb --format='{{range .Mounts }}{{.Name}}{{end}}'
+069ba64815f0c26783b81a5f0ca813227fde8491f429cf77ed9a5ae3536c0b2c
+```
+
+2. [Bind-mounts][bind-mounts] -- to get the current mount path use:
+```bash
+$ docker inspect timescaledb --format='{{range .Mounts }}{{.Source}}{{end}}'
+/path/to/data
+```
+
+#### Step 3: Stop old container [](update-docker-3)
+If the container is currently running, stop and remove it in order to connect
+the new one.
+
+```bash
+docker stop timescaledb
+docker rm timescaledb
+```
+
+#### Step 4: Start new container [](update-docker-4)
+Launch a new container with the updated docker image, but pointing to
+the existing mount point. This will again differ by mount type.
+
+1. For volume mounts you can use:
+```bash
+docker run -v 069ba64815f0c26783b81a5f0ca813227fde8491f429cf77ed9a5ae3536c0b2c:/var/lib/postgresql/data -d --name timescaledb -p 5432:5432 timescale/timescaledb
+```
+
+2. If using bind-mounts, you need to run:
+```bash
+docker run -v /path/to/data:/var/lib/postgresql/data -d --name timescaledb -p 5432:5432 timescale/timescaledb
+```
+
+
+#### Step 5: Run ALTER EXTENSION [](update-docker-5)
+Finally, connect to this instance via `psql` (with the `-X` flag) and execute the `ALTER` command
+as above in order to update the extension to the latest version:
+
+```bash
+docker exec -it timescaledb psql -U postgres -X
+
+# within the PostgreSQL instance
+ALTER EXTENSION timescaledb UPDATE;
+```
+
+You can then run the `\dx` command to make sure you have the
+latest version of TimescaleDB installed.
+
+[upgrade-pg]: /using-timescaledb/update-timescale/upgrade-pg
+[update-db-1]: /using-timescaledb/update-timescale/update-db-1
+[update-db-2]: /using-timescaledb/update-timescale/update-db-2
+[pg_upgrade]: https://www.postgresql.org/docs/current/static/pgupgrade.html
+[backup]: /using-timescaledb/backup
+[Install]: /getting-started/installation
+[telemetry]: /using-timescaledb/telemetry
+[volumes]: https://docs.docker.com/engine/admin/volumes/volumes/
+[bind-mounts]: https://docs.docker.com/engine/admin/volumes/bind-mounts/

--- a/update-timescaledb/update-docker.md
+++ b/update-timescaledb/update-docker.md
@@ -1,6 +1,6 @@
 # Updating a TimescaleDB Docker installation
 
-As a more concrete example, the following steps should be taken with a docker
+The following steps should be taken with a docker
 installation to upgrade to the latest TimescaleDB version, while
 retaining data across the updates.
 

--- a/update-timescaledb/update-tsdb-1.md
+++ b/update-timescaledb/update-tsdb-1.md
@@ -1,0 +1,148 @@
+# Updating TimescaleDB 1.x [](update)
+
+Use these instructions to update TimescaleDB within the 1.x version.
+
+>:TIP:TimescaleDB 2.0 is currently available as a release candidate and we encourage
+>users to upgrade in testing environments to gain experience and provide feedback on 
+>new and updated features.
+>
+>See [Changes in TimescaleDB 2.0]() for more information and links to installation 
+>instructions
+
+### TimescaleDB Release Compatibility
+
+TimescaleDB 1.x is currently supported by the following PostgreSQL releases.
+
+ TimescaleDB Release |   Supported PostgreSQL Release
+ --------------------|-------------------------------
+ 1.3 - 1.7.4         | 9.6, 10, 11, 12
+
+If you need to upgrade PostgreSQL first, please see [our documentation][upgrade-pg].
+
+### Update TimescaleDB
+
+Software upgrades use PostgreSQL's `ALTER EXTENSION` support to update to the
+latest version. TimescaleDB supports having different extension
+versions on different databases within the same PostgreSQL instance. This
+allows you to update extensions independently on different databases. The
+upgrade process involves three-steps:
+
+1. We recommend that you perform a [backup][] of your database via `pg_dump`.
+1. [Install][] the latest version of the TimescaleDB extension.
+1. Execute the following `psql` command inside any database that you want to
+   update:
+
+```sql
+ALTER EXTENSION timescaledb UPDATE;
+```
+
+>:WARNING: When executing `ALTER EXTENSION`, you should connect using `psql`
+with the `-X` flag to prevent any `.psqlrc` commands from accidentally
+triggering the load of a previous TimescaleDB version on session startup. 
+It must also be the first command you execute in the session. 
+<!-- -->
+
+This will upgrade TimescaleDB to the latest installed version, even if you
+are several versions behind.
+
+After executing the command, the psql `\dx` command should show the latest version:
+
+```sql
+\dx timescaledb
+
+    Name     | Version |   Schema   |                             Description
+-------------+---------+------------+---------------------------------------------------------------------
+ timescaledb | x.y.z   | public     | Enables scalable inserts and complex queries for time-series data
+(1 row)
+```
+
+### Example: Migrating docker installations [](update-docker)
+
+As a more concrete example, the following steps should be taken with a docker
+installation to upgrade to the latest TimescaleDB version, while
+retaining data across the updates.
+
+The following instructions assume that your docker instance is named
+`timescaledb`. If not, replace this name with the one you use in the subsequent
+commands.
+
+#### Step 1: Pull new image [](update-docker-1)
+Install the latest TimescaleDB image:
+
+```bash
+docker pull timescale/timescaledb:latest-pg12
+```
+>:TIP: If you are using PostgreSQL 11 images, use the tag `latest-pg11`.
+
+#### Step 2: Determine mount point used by old container [](update-docker-2)
+As you'll want to restart the new docker image pointing to a mount point
+that contains the previous version's data, we first need to determine
+the current mount point.
+
+There are two types of mounts. To find which mount type your old container is
+using you can run the following command:
+```bash
+docker inspect timescaledb --format='{{range .Mounts }}{{.Type}}{{end}}'
+```
+This command will return either `volume` or `bind`, corresponding
+to the two options below.
+
+1. [Volumes][volumes] -- to get the current volume name use:
+```bash
+$ docker inspect timescaledb --format='{{range .Mounts }}{{.Name}}{{end}}'
+069ba64815f0c26783b81a5f0ca813227fde8491f429cf77ed9a5ae3536c0b2c
+```
+
+2. [Bind-mounts][bind-mounts] -- to get the current mount path use:
+```bash
+$ docker inspect timescaledb --format='{{range .Mounts }}{{.Source}}{{end}}'
+/path/to/data
+```
+
+#### Step 3: Stop old container [](update-docker-3)
+If the container is currently running, stop and remove it in order to connect
+the new one.
+
+```bash
+docker stop timescaledb
+docker rm timescaledb
+```
+
+#### Step 4: Start new container [](update-docker-4)
+Launch a new container with the updated docker image, but pointing to
+the existing mount point. This will again differ by mount type.
+
+1. For volume mounts you can use:
+```bash
+docker run -v 069ba64815f0c26783b81a5f0ca813227fde8491f429cf77ed9a5ae3536c0b2c:/var/lib/postgresql/data -d --name timescaledb -p 5432:5432 timescale/timescaledb
+```
+
+2. If using bind-mounts, you need to run:
+```bash
+docker run -v /path/to/data:/var/lib/postgresql/data -d --name timescaledb -p 5432:5432 timescale/timescaledb
+```
+
+
+#### Step 5: Run ALTER EXTENSION [](update-docker-5)
+Finally, connect to this instance via `psql` (with the `-X` flag) and execute the `ALTER` command
+as above in order to update the extension to the latest version:
+
+```bash
+docker exec -it timescaledb psql -U postgres -X
+
+# within the PostgreSQL instance
+ALTER EXTENSION timescaledb UPDATE;
+```
+
+You can then run the `\dx` command to make sure you have the
+latest version of TimescaleDB installed.
+
+[upgrade-pg]: /update-timescaledb/upgrade-pg
+[update-tsdb-1]: /update-timescaledb/update-db-1
+[update-tsdb-2]: https://docs.timescale.com/v2.0/update-timescaledb/update-db-2
+[pg_upgrade]: https://www.postgresql.org/docs/current/static/pgupgrade.html
+[backup]: /using-timescaledb/backup
+[Install]: /getting-started/installation
+[telemetry]: /using-timescaledb/telemetry
+[volumes]: https://docs.docker.com/engine/admin/volumes/volumes/
+[bind-mounts]: https://docs.docker.com/engine/admin/volumes/bind-mounts/

--- a/update-timescaledb/update-tsdb-2.md
+++ b/update-timescaledb/update-tsdb-2.md
@@ -2,12 +2,11 @@
 
 Use these instructions to update TimescaleDB 1.x to TimescaleDB 2.0
 
-
 >:WARNING:These instructions are only for upgrading TimescaleDB 1.x to TimescaleDB 2.0
 > If you need to upgrade your existing TimescaleDB 1.x to a newer version in the 1.x
-> release line (eg. 1.7.2 to 1.7.4), please see Update [TimescaleDB 1.x][update-tsdb-1]
+> release line (eg. 1.7.2 to 1.7.4), please see Update [TimescaleDB 1.x][update-tsdb-1].
 
-### TimescaleDB Release Compatibility
+### TimescaleDB Release Compatibility [](compatibility)
 
 TimescaleDB 2.0 currently supports the following PostgreSQL releases. If you are not currently running 
 a compatible release, please upgrade before updating TimescaleDB.
@@ -22,15 +21,24 @@ a compatible release, please upgrade before updating TimescaleDB.
 TimescaleDB 2.0 supports **in-place updates** just like previous releases. During the update, scripts will automatically configure
 updated features to work as expected with TimescaleDB 2.0.
 
-Because this is our first major version release in two years, however, we’re providing additional guidance to help you ensure the update completes successfully and everything is configured as expected (and optimized for your workload). In particular, settings related to [Continuous Aggregates][caggs], [compression][compression], and [data retention][retention] have been modified to provide greater configuration transparency and flexibility, therefore we highly recommend verifying that these settings were migrated correctly.
+Because this is our first major version release in two years, however, we’re providing additional guidance 
+to help you ensure the update completes successfully and everything is configured as expected (and optimized 
+for your workload). In particular, settings related to [Continuous Aggregates][caggs], [compression][compression], 
+and [data retention][retention] have been modified to provide greater configuration transparency and flexibility, 
+therefore we highly recommend verifying that these settings were migrated correctly.
 
-**Before completing the upgrade**, we encourage you to read [Changes in TimescaleDB 2.0][changes-in-ts2] for a more detailed look at the major changes in TimescaleDB 2.0 and how they impact the way your applications and scripts interact with the API.
+**Before completing the upgrade**, we encourage you to read [Changes in TimescaleDB 2.0][changes-in-ts2] for a more 
+detailed look at the major changes in TimescaleDB 2.0 and how they impact the way your applications and scripts 
+interact with the API.
 
-### Prerequisites
+### Prerequisites [](prerequisites)
 #### PostgreSQL Compatibility
-**TimescaleDB 2.0 is not compatible with PostgreSQL 9.6 or 10**. If your current PostgreSQL installation is not at least version 11, please upgrade PostgreSQL first. Depending on your current PostgreSQL version and installed TimescaleDB release, you may have to perform multiple upgrades because of compatibility restrictions.
+**TimescaleDB 2.0 is not compatible with PostgreSQL 9.6 or 10**. If your current PostgreSQL installation is not 
+at least version 11, please upgrade PostgreSQL first. Depending on your current PostgreSQL version and installed 
+TimescaleDB release, you may have to perform multiple upgrades because of compatibility restrictions.
 
-For example, if you are currently running PostgreSQL 10 and TimescaleDB 1.5, the recommended upgrade path to PostgreSQL 12 and TimescaleDB 2.0 would be:
+For example, if you are currently running PostgreSQL 10 and TimescaleDB 1.5, the recommended upgrade path to 
+PostgreSQL 12 and TimescaleDB 2.0 would be:
 
 1. Update TimescaleDB 1.5 to TimescaleDB 1.7 on PostgreSQL 10
 1. Upgrade PostgreSQL 10 to PostgreSQL 12 with TimescaleDB 1.7 installed
@@ -39,12 +47,16 @@ For example, if you are currently running PostgreSQL 10 and TimescaleDB 1.5, the
 >:TIP: Whenever possible, prefer the most recent supported version, PostgreSQL 12. Please see our [Upgrading PostgreSQL][upgrade-pg] guide for help.
 
 #### Fix Continuous Aggregate Errors Before Upgrading
-Before starting the upgrade to TimescaleDB 2.0, **we highly recommend checking the database log for errors related to failed retention policies that were occurring in TimescaleDB 1.x** and then either remove them or update them to be compatible with existing continuous aggregates. Any remaining retention policies that are still incompatible with the 'ignore_invalidation_older_than' setting will automatically be disabled during the upgrade and a notice provided.
+Before starting the upgrade to TimescaleDB 2.0, **we highly recommend checking the database log for errors 
+related to failed retention policies that were occurring in TimescaleDB 1.x** and then either remove them or 
+update them to be compatible with existing continuous aggregates. Any remaining retention policies that are 
+still incompatible with the 'ignore_invalidation_older_than' setting will automatically be disabled during 
+the upgrade and a notice provided.
 
 >:TIP:Read more about changes to continuous aggregates and data retension policies [here][retention-cagg-changes]
 
 
-### Update TimescaleDB
+### Update TimescaleDB [](start-update)
 
 #### Step 1: Verify TimescaleDB 1.x Policy Settings (Optional)
 
@@ -146,9 +158,12 @@ hypertable_name   | _materialized_hypertable_2
 
 Verify the information for each policy type that was exported from TimescaleDB 1.x using the specific
 listing of `jobs` in this view. For continuous aggregates, take special note of the `config` information
-to verify that all settings were converted correctly given the notes in the [Updating existing continuous aggregates][changes-in-ts2-caggs] section of our migration document.
+to verify that all settings were converted correctly given the notes in the 
+[Updating existing continuous aggregates][changes-in-ts2-caggs] section of our migration document.
 
-Likewise, you can now verify that all jobs scheduled and running as expected with the new `timescaledb_information.job_stats` view. Given the continuous aggregate `job` above, querying the new `job_stats` view might return information similar to the following.
+Likewise, you can now verify that all jobs scheduled and running as expected with the new `timescaledb_information.job_stats` 
+view. Given the continuous aggregate `job` above, querying the new `job_stats` view might return information similar 
+to the following.
 
 ```SQL
 SELECT * FROM timescaledb_information.job_stats

--- a/update-timescaledb/update-tsdb-2.md
+++ b/update-timescaledb/update-tsdb-2.md
@@ -1,0 +1,187 @@
+# Updating TimescaleDB to 2.0 [](update)
+
+Use these instructions to update TimescaleDB 1.x to TimescaleDB 2.0
+
+
+>:WARNING:These instructions are only for upgrading TimescaleDB 1.x to TimescaleDB 2.0
+> If you need to upgrade your existing TimescaleDB 1.x to a newer version in the 1.x
+> release line (eg. 1.7.2 to 1.7.4), please see Update [TimescaleDB 1.x][update-tsdb-1]
+
+### TimescaleDB Release Compatibility
+
+TimescaleDB 2.0 currently supports the following PostgreSQL releases. If you are not currently running 
+a compatible release, please upgrade before updating TimescaleDB.
+
+ TimescaleDB Release |   Supported PostgreSQL Release
+ --------------------|-------------------------------
+ 2.0-RC1+            | 11, 12
+
+>:TIP:If you need to upgrade PostgreSQL first, please see [our documentation][upgrade-pg].
+
+### Notice of breaking changes from TimescaleDB 1.3+
+TimescaleDB 2.0 supports **in-place updates** just like previous releases. During the update, scripts will automatically configure
+updated features to work as expected with TimescaleDB 2.0.
+
+Because this is our first major version release in two years, however, we’re providing additional guidance to help you ensure the update completes successfully and everything is configured as expected (and optimized for your workload). In particular, settings related to [Continuous Aggregates][caggs], [compression][compression], and [data retention][retention] have been modified to provide greater configuration transparency and flexibility, therefore we highly recommend verifying that these settings were migrated correctly.
+
+**Before completing the upgrade**, we encourage you to read [Changes in TimescaleDB 2.0][changes-in-ts2] for a more detailed look at the major changes in TimescaleDB 2.0 and how they impact the way your applications and scripts interact with the API.
+
+### Prerequisites
+#### PostgreSQL Compatibility
+**TimescaleDB 2.0 is not compatible with PostgreSQL 9.6 or 10**. If your current PostgreSQL installation is not at least version 11, please upgrade PostgreSQL first. Depending on your current PostgreSQL version and installed TimescaleDB release, you may have to perform multiple upgrades because of compatibility restrictions.
+
+For example, if you are currently running PostgreSQL 10 and TimescaleDB 1.5, the recommended upgrade path to PostgreSQL 12 and TimescaleDB 2.0 would be:
+
+1. Update TimescaleDB 1.5 to TimescaleDB 1.7 on PostgreSQL 10
+1. Upgrade PostgreSQL 10 to PostgreSQL 12 with TimescaleDB 1.7 installed
+1. Update TimescaleDB 1.7 to TimescaleDB 2.0 on PostgreSQL with the instructions below
+
+>:TIP: Whenever possible, prefer the most recent supported version, PostgreSQL 12. Please see our [Upgrading PostgreSQL][upgrade-pg] guide for help.
+
+#### Fix Continuous Aggregate Errors Before Upgrading
+Before starting the upgrade to TimescaleDB 2.0, **we highly recommend checking the database log for errors related to failed retention policies that were occurring in TimescaleDB 1.x** and then either remove them or update them to be compatible with existing continuous aggregates. Any remaining retention policies that are still incompatible with the 'ignore_invalidation_older_than' setting will automatically be disabled during the upgrade and a notice provided.
+
+>:TIP:Read more about changes to continuous aggregates and data retension policies [here][retention-cagg-changes]
+
+
+### Update TimescaleDB
+
+#### Step 1: Verify TimescaleDB 1.x Policy Settings (Optional)
+
+As discussed in the [Changes to TimescaleDB 2.0][changes-in-ts2] document, the APIs and setting names
+that configure various policies are changing. The update process below will automatically configure
+new policies using your current configurations in TimescaleDB 1.x.  If you would like to verify
+the policy settings after the update is complete, we suggest querying the informational views below
+and saving the output so that you can refer to it once the update is complete.
+
+Execute the following SQL to save current settings for Continuous Aggregates and other policies to CSV using `psql`. If you use an IDE like **pgAdmin** or **DBeaver**, save the output to CSV or another appropriate format to inspect later.
+
+**Policy Stats**
+```SQL
+\COPY timescaledb_information.policy_stats TO ‘policy_stats.csv’ csv header
+```
+
+**Continuous Aggregate Stats**
+```SQL
+\COPY timescaledb_information.continuous_aggregates_stats TO ‘continuous_aggregates_stats.csv’ csv header
+```
+
+**Drop Chunk Policies**
+```SQL
+\COPY timescaledb_information.drop_chunks_policies TO ‘drop_chunk_policies.csv’ csv header
+```
+**Reorder Policy Stats**
+```SQL
+\COPY timescaledb_information.reorder_policies TO ‘reorder_policies.csv’ csv header
+```
+
+#### Step 2: Install and Update TimescaleDB Extension
+
+Software upgrades use PostgreSQL's `ALTER EXTENSION` support to update to the
+latest version. TimescaleDB supports having different extension
+versions on different databases within the same PostgreSQL instance. This
+allows you to update extensions independently on different databases.  The
+upgrade process involves three-steps:
+
+1. We recommend that you perform a [backup][] of your database via `pg_dump`.
+1. [Install][] the latest version of the TimescaleDB extension.
+1. Execute the following `psql` command inside any database that you want to
+   update:
+
+```sql
+ALTER EXTENSION timescaledb UPDATE;
+```
+
+>:WARNING: When executing `ALTER EXTENSION`, you should connect using `psql`
+with the `-X` flag to prevent any `.psqlrc` commands from accidentally
+triggering the load of a previous TimescaleDB version on session startup. 
+It must also be the first command you execute in the session. 
+<!-- -->
+
+This will upgrade TimescaleDB to the latest installed version, even if you
+are several versions behind.
+
+After executing the command, the psql `\dx` command should show the latest version:
+
+```sql
+\dx timescaledb
+
+    Name     | Version |   Schema   |                             Description
+-------------+---------+------------+---------------------------------------------------------------------
+ timescaledb | x.y.z   | public     | Enables scalable inserts and complex queries for time-series data
+(1 row)
+```
+
+#### Step 3: Verify Updated Policy Settings and Jobs
+
+All settings and information previously accessed through separate `stats` informational views have now
+been centralized to a common `jobs` view for all types of policies. If you wish to verify that the settings
+were moved correctly, query the `timescaledb_information.jobs` view to verify that each policy was correctly
+moved and enabled based on your TimescaleDB 1.x setup.
+
+In the example below, we query for all continuous aggregate policy `jobs`. Compare the names and settings
+to the values of the data exported from `timescaledb_information.continuous_aggregates`:
+
+```SQL
+SELECT * FROM timescaledb_information.jobs
+  WHERE application_name LIKE 'Refresh Continuous%';
+
+-[ RECORD 1 ]-----+--------------------------------------------------
+job_id            | 1001
+application_name  | Refresh Continuous Aggregate Policy [1001]
+schedule_interval | 01:00:00
+max_runtime       | 00:00:00
+max_retries       | -1
+retry_period      | 01:00:00
+proc_schema       | _timescaledb_internal
+proc_name         | policy_refresh_continuous_aggregate
+owner             | postgres
+scheduled         | t
+config            | {"start_offset": "20 days", "end_offset": "10 
+days", "mat_hypertable_id": 2}
+next_start        | 2020-10-02 12:38:07.014042-04
+hypertable_schema | _timescaledb_internal
+hypertable_name   | _materialized_hypertable_2
+```
+
+Verify the information for each policy type that was exported from TimescaleDB 1.x using the specific
+listing of `jobs` in this view. For continuous aggregates, take special note of the `config` information
+to verify that all settings were converted correctly given the notes in the [Updating existing continuous aggregates][changes-in-ts2-caggs] section of our migration document.
+
+Likewise, you can now verify that all jobs scheduled and running as expected with the new `timescaledb_information.job_stats` view. Given the continuous aggregate `job` above, querying the new `job_stats` view might return information similar to the following.
+
+```SQL
+SELECT * FROM timescaledb_information.job_stats
+  WHERE job_id = 1001;
+
+-[ RECORD 1 ]----------+------------------------------
+hypertable_schema      | _timescaledb_internal
+hypertable_name        | _materialized_hypertable_2
+job_id                 | 1001
+last_run_started_at    | 2020-10-02 09:38:06.871953-04
+last_successful_finish | 2020-10-02 09:38:06.932675-04
+last_run_status        | Success
+job_status             | Scheduled
+last_run_duration      | 00:00:00.060722
+next_scheduled_run     | 2020-10-02 10:38:06.932675-04
+total_runs             | 1
+total_successes        | 1
+total_failures         | 0
+```
+
+
+[upgrade-pg]: /update-timescaledb/upgrade-pg
+[update-tsdb-1]: /update-timescaledb/update-db-1
+[update-tsdb-2]: /update-timescaledb/update-db-2
+[pg_upgrade]: https://www.postgresql.org/docs/current/static/pgupgrade.html
+[backup]: /using-timescaledb/backup
+[Install]: /getting-started/installation
+[telemetry]: /using-timescaledb/telemetry
+[volumes]: https://docs.docker.com/engine/admin/volumes/volumes/
+[bind-mounts]: https://docs.docker.com/engine/admin/volumes/bind-mounts/
+[caggs]: /using-timescaledb/continuous-aggregates
+[compression]: /using-timescaledb/compression
+[retention]: /using-timescaledb/data-retention
+[retention-cagg-changes]: /getting-started/changes-in-timescaledb-2#retention-and-caggs
+[changes-in-ts2]: /release-notes/changes-in-timescaledb-2
+[changes-in-ts2-caggs]: /release-notes/changes-in-timescaledb-2#updating-continuous-aggregates

--- a/update-timescaledb/update-tsdb-2.md
+++ b/update-timescaledb/update-tsdb-2.md
@@ -50,10 +50,10 @@ PostgreSQL 12 and TimescaleDB 2.0 would be:
 Before starting the upgrade to TimescaleDB 2.0, **we highly recommend checking the database log for errors 
 related to failed retention policies that were occurring in TimescaleDB 1.x** and then either remove them or 
 update them to be compatible with existing continuous aggregates. Any remaining retention policies that are 
-still incompatible with the 'ignore_invalidation_older_than' setting will automatically be disabled during 
+still incompatible with the `ignore_invalidation_older_than` setting will automatically be disabled during 
 the upgrade and a notice provided.
 
->:TIP:Read more about changes to continuous aggregates and data retension policies [here][retention-cagg-changes]
+>:TIP:Read more about changes to continuous aggregates and data retension policies [here][retention-cagg-changes].
 
 
 ### Update TimescaleDB [](start-update)

--- a/update-timescaledb/upgrade-pg.md
+++ b/update-timescaledb/upgrade-pg.md
@@ -1,0 +1,31 @@
+
+# Upgrade PostgreSQL
+
+Each release of TimescaleDB is compatible with specific versions of PostgreSQL. Over time we will add support
+for a newer version of PostgreSQL while simultaneously dropping support for an older versions. 
+
+When the supported versions of PostgreSQL changes, you may need to upgrade the version of the **PostgreSQL instance** (e.g. from 10 to 12) before you can install the latest release of TimescaleDB
+
+To upgrade PostgreSQL, you have two choices, as outlined in the PostgreSQL online documentation. 
+
+### Use `pg_upgrade`
+
+[`pg_upgrade`][pg_upgrade] is a tool that avoids the need to dump all data and then import it
+into a new instance of PostgreSQL after a new version is installed. Instead, `pg_update` allows you to 
+retain the data files of your current PostgreSQL installation while binding the new PostgreSQL binary
+runtime to them. This is currently supported for all releases 8.4 and greater.:
+
+ ```
+ pg_upgrade -b oldbindir -B newbindir -d olddatadir -D newdatadir"
+ ```
+
+### Use `pg_dump` and `pg_restore`
+When `pg_upgrade` is not an option, such as moving data to a new physical instance of PostgreSQL, using the 
+tried and true method of dumping all data in the database and then restoring into a database in the new instance
+is always supported with PostgreSQL and TimescaleDB.
+
+Please see our documentation on [Backup & Restore][backup] strategies for more information.
+
+
+[pg_upgrade]: https://www.postgresql.org/docs/current/static/pgupgrade.html
+[backup]: /using-timescaledb/backup

--- a/update-timescaledb/upgrade-pg.md
+++ b/update-timescaledb/upgrade-pg.md
@@ -4,7 +4,7 @@
 Each release of TimescaleDB is compatible with specific versions of PostgreSQL. Over time we will add support
 for a newer version of PostgreSQL while simultaneously dropping support for an older versions. 
 
-When the supported versions of PostgreSQL changes, you may need to upgrade the version of the **PostgreSQL instance** (e.g. from 10 to 12) before you can install the latest release of TimescaleDB
+When the supported versions of PostgreSQL changes, you may need to upgrade the version of the **PostgreSQL instance** (e.g. from 10 to 12) before you can install the latest release of TimescaleDB.
 
 To upgrade PostgreSQL, you have two choices, as outlined in the PostgreSQL online documentation. 
 
@@ -13,7 +13,7 @@ To upgrade PostgreSQL, you have two choices, as outlined in the PostgreSQL onlin
 [`pg_upgrade`][pg_upgrade] is a tool that avoids the need to dump all data and then import it
 into a new instance of PostgreSQL after a new version is installed. Instead, `pg_update` allows you to 
 retain the data files of your current PostgreSQL installation while binding the new PostgreSQL binary
-runtime to them. This is currently supported for all releases 8.4 and greater.:
+runtime to them. This is currently supported for all releases 8.4 and greater.
 
  ```
  pg_upgrade -b oldbindir -B newbindir -d olddatadir -D newdatadir"

--- a/using-timescaledb.md
+++ b/using-timescaledb.md
@@ -32,12 +32,14 @@ compatible with the PostgreSQL streaming replication protocol, as explained in o
 [streaming replication tutorial][replication]. Streaming replication setups can be
 further extended to offer high availability and failover using community tools like [patroni][patroni].
 
-Write clustering for multi-node TimescaleDB deployments is under active development, and we're
-excited to share our progress with the community soon. That being said, workloads that
-may require a multi-node deployment on NoSQL databases can often be handled by
-a single TimescaleDB instance with one or more read replicas. The power of using a
-relational database to handle production-level time series data is discussed in further
-detail in this [blog post][nosql-blog-post].
+Write clustering for multi-node TimescaleDB deployments is now available with
+TimescaleDB 2.0. Read more about [multi-node capabilities][multi-node-basic] 
+or join our #multinode channel in our [community Slack][slack]
+
+That being said, workloads that may require a multi-node deployment on NoSQL databases
+can often be handled by a single TimescaleDB instance with one or more read replicas. 
+The power of using a relational database to handle production-level time series data 
+is discussed in further detail in this [blog post][nosql-blog-post].
 
 If you're entirely new to PostgreSQL, here are some resources to help you get started:
 - [PostgreSQL Manuals][postgres-manuals]
@@ -57,3 +59,5 @@ If you're entirely new to SQL, here are some resources to help you get started:
 [tutorialspoint]: https://www.tutorialspoint.com/sql/
 [khanacademy]: https://www.khanacademy.org/computing/computer-programming/sql
 [codecademy]: https://www.codecademy.com/learn/learn-sql
+[slack]: https://slack.timescale.com/
+[multi-node-basic]: /getting-started/setup-multi-node-basic

--- a/using-timescaledb/distributed-hypertables.md
+++ b/using-timescaledb/distributed-hypertables.md
@@ -1,8 +1,8 @@
 # Distributed Hypertables
 
->:WARNING: Distributed hypertables are currently in BETA and
-are not yet meant for production use. For more information, please
-[contact us][contact] or join the #multinode-beta channel in our 
+>:WARNING: Distributed hypertables and [multi-node capabilities][multi-node-basic]
+are currently in BETA. This feature is not meant for production use. For more information,
+please [contact us][contact] or join the #multinode channel in our 
 [community Slack][slack].
 
 Hypertables handle large amounts of data by breaking it up into

--- a/using-timescaledb/troubleshooting.md
+++ b/using-timescaledb/troubleshooting.md
@@ -108,7 +108,7 @@ and then inspect `dump_file.txt` before sending it together with a bug report or
 
 [slack]: https://slack.timescale.com/
 [github]: https://github.com/timescale/timescaledb/issues
-[update-db]: /using-timescaledb/update-db
+[update-db]: /update-timescaledb
 [using explain]: https://www.postgresql.org/docs/current/static/using-explain.html
 [track_io_timing]: https://www.postgresql.org/docs/current/static/runtime-config-statistics.html#GUC-TRACK-IO-TIMING
 [downloaded separately]: https://raw.githubusercontent.com/timescale/timescaledb/master/scripts/dump_meta_data.sql


### PR DESCRIPTION
**NOTE**: These changes should ONLY be applied to the 2.0 branch. A separate PR will target 1.7 branch with appropriate changes there.

These changes include:
* removed "Update Software" from the "Using TimescaleDB" section
* changes to the Install pages, including:
  * removing unsupported install types
  * modifying all supported install docs to point to 2.0.0-rc1 (and other verbiage as appropriate)
* addition of a new main navigation category "Update TimescaleDB"
* sub-pages below the new category for detailed install docs
* addition of a migration/changes doc for 2.0 under "Release Notes"


