### PR TITLE
Fix distributed_exec to correspond to the implementation

### DIFF
--- a/api.md
+++ b/api.md
@@ -909,10 +909,16 @@ SELECT detach_tablespaces('conditions');
 ---
 ## distributed_exec() [](distributed_exec)
 
-This function is used on an access node to execute a SQL command
+This procedure is used on an access node to execute a SQL command
 across the data nodes of a distributed database. For instance, one use
 case is to create the roles and permissions needed in a distributed
 database.
+
+The procedure can run distributed commands transactionally, so a command
+is executed either everywhere or nowhere. However, not all SQL commands can run in a 
+transaction. This can be toggled with the argument `transactional`. Note if the execution 
+is not transactional, a failure on one of the data node will require manual dealing with
+the appeared inconsistency.
 
 Note that the command is _not_ executed on the access node itself and
 it is not possible to chain multiple commands together in one call.
@@ -928,21 +934,28 @@ it is not possible to chain multiple commands together in one call.
 |Name|Description|
 |---|---|
 | `node_list` | An array of data nodes where the command should be executed. Defaults to all data nodes if not specified. |
+| `transactional` | Allows to specify if the execution of the statement should be transactional or not. Defaults to TRUE. |
 
 #### Sample Usage [](distributed_exec-examples)
 
-Create the role `davide` across all data nodes in a distributed database:
+Create the role `testrole` across all data nodes in a distributed database:
 
 ```sql
-SELECT distributed_exec($$CREATE USER davide WITH PASSWORD 'jw8s0F4'$$);
+CALL distributed_exec($$ CREATE USER testrole WITH LOGIN $$);
 
 ```
 
-Create the role `davide` on two specific data nodes:
+Create the role `testrole` on two specific data nodes:
 
 ```sql
-SELECT distributed_exec($$CREATE USER davide WITH PASSWORD 'jw8s0F4'$$, node_list => '{ "dn1", "dn2" }');
+CALL distributed_exec($$ CREATE USER testrole WITH LOGIN $$, node_list => '{ "dn1", "dn2" }');
 
+```
+
+Create new databases `dist_database` on data nodes, which requires to set `transactional` to FALSE:
+
+```sql
+CALL distributed_exec('CREATE DATABASE dist_database', transactional => FALSE);
 ```
 
 ---

--- a/api.md
+++ b/api.md
@@ -918,7 +918,7 @@ The procedure can run distributed commands transactionally, so a command
 is executed either everywhere or nowhere. However, not all SQL commands can run in a 
 transaction. This can be toggled with the argument `transactional`. Note if the execution 
 is not transactional, a failure on one of the data node will require manual dealing with
-the appeared inconsistency.
+any introduced inconsistency.
 
 Note that the command is _not_ executed on the access node itself and
 it is not possible to chain multiple commands together in one call.

--- a/getting-started/setup-multi-node-auth.md
+++ b/getting-started/setup-multi-node-auth.md
@@ -82,11 +82,11 @@ CREATE ROLE alice WITH LOGIN PASSWORD 'foobar';
 
 Note: The `postgres` user should already exist, so shouldn't need to be added to each node.
 
-Then, to create the same user on all data nodes, use the `distributed_exec` function 
+Then, to create the same user on all data nodes, use the `distributed_exec` procedure 
 ([API docs][distributed_exec]) from the access node:
 
 ```sql
-SELECT distributed_exec($$CREATE USER alice WITH PASSWORD 'foobar'$$);
+CALL distributed_exec($$CREATE USER alice WITH PASSWORD 'foobar'$$);
 ```
 
 and the system setup is complete.

--- a/tutorials/clustering.md
+++ b/tutorials/clustering.md
@@ -163,11 +163,11 @@ SELECT * FROM timescaledb_information.data_node;
 
 Now that you have created a database and added a couple data nodes, let's go
 ahead and create a new user role we can use for our distributed database.
-You can use Timescale's `distributed_exec` function to perform this action on
+You can use Timescale's `distributed_exec` procedure to perform this action on
 the data nodes:
 ```sql
 CREATE ROLE testuser WITH LOGIN PASSWORD 'testpass';
-SELECT * FROM distributed_exec($$ CREATE ROLE testuser WITH LOGIN PASSWORD 'testpass' $$);
+CALL distributed_exec($$ CREATE ROLE testuser WITH LOGIN PASSWORD 'testpass' $$);
 ```
 
 This creates the same user role on all the data nodes. It is important that


### PR DESCRIPTION
distributed_exec was fixed in timescale/timescaledb#2520 to allow
execution of statements outside transactions in addition to
transactional executions. It was also changed from being a function to
be a procedure. This commit aligns the description of distributed_exec
and examples to use CALL.
