### PR TITLE
Clarify limitation of start and finish in gapfill

### DIFF
--- a/api.md
+++ b/api.md
@@ -2660,6 +2660,11 @@ call (unless as a subquery where the outer query does the type cast).
 | `start` | The start of the gapfill period (timestamp/timestamptz/date)|
 | `finish` | The end of the gapfill period (timestamp/timestamptz/date)|
 
+Note that explicitly provided `start` and `stop` or derived from WHERE clause values 
+need to be simple expressions. Such expressions should be evaluated to constants 
+at the query planning. For example, simple expressions can contain constants or 
+call to `now()`, but cannot reference to columns of a table.
+
 ### For Integer Time Inputs
 
 #### Required Arguments [](time_bucket_gapfill-integer-required-arguments)


### PR DESCRIPTION
Clarifies that start and finish values of time_bucket_gapfill can be
simple expressions and cannot reference to table columns.

Part of timescale/timescaledb#2595
