### PR TITLE
Updated Continuous Aggregate Tutorial and some associated API fixes

### DIFF
--- a/api.md
+++ b/api.md
@@ -11,7 +11,7 @@
 > - [add_retention_policy](#add_retention_policy)
 > - [alter_job](#alter_job)
 > - [alter table (compression)](#compression_alter-table)
-> - [alter view (continuous aggregate)](#continuous_aggregate-alter_view)
+> - [alter materialized view (continuous aggregate)](#continuous_aggregate-alter_view)
 > - [approximate_row_count](#approximate_row_count)
 > - [attach_data_node](#attach_data_node)
 > - [attach_tablespace](#attach_tablespace)
@@ -21,7 +21,7 @@
 > - [create_distributed_hypertable](#create_distributed_hypertable)
 > - [create_hypertable](#create_hypertable)
 > - [create index (transaction per chunk)](#create_index)
-> - [create view (continuous aggregate)](#continuous_aggregate-create_view)
+> - [create materialized view (continuous aggregate)](#continuous_aggregate-create_view)
 > - [decompress_chunk](#decompress_chunk)
 > - [delete_data_node](#delete_data_node)
 > - [delete_job](#delete_job)
@@ -30,7 +30,7 @@
 > - [detach_tablespaces](#detach_tablespaces)
 > - [distributed_exec](#distributed_exec)
 > - [drop_chunks](#drop_chunks)
-> - [drop view (continuous aggregate)](#continuous_aggregate-drop_view)
+> - [drop materialized view (continuous aggregate)](#continuous_aggregate-drop_view)
 > - [first](#first)
 > - [get_telemetry_report](#get_telemetry_report)
 > - [histogram](#histogram)
@@ -1751,10 +1751,6 @@ WITH (timescaledb.continuous) AS
     GROUP BY time_bucket('30day', timec);
 ```
 
->:TIP: In order to keep the continuous aggregate up to date with incoming data,
-the refresh lag can be set to `-<bucket_width>`. Please note that by doing so,
-you will incur higher write amplification and incur performance penalties.
-
 ```sql
 CREATE MATERIALIZED VIEW continuous_aggregate_view( timec, minl, sumt, sumh )
 WITH (timescaledb.continuous) AS
@@ -1763,6 +1759,10 @@ WITH (timescaledb.continuous) AS
     GROUP BY time_bucket('1h', timec);
 ```
 
+>:TIP: In order to keep the continuous aggregate up to date with incoming data,
+>the `end_offset` of the [continuous aggregate policy](#add_continuous_aggregate_policy)
+>can be set to `-<bucket_width>`. Please note that by doing so, you will incur higher 
+>write amplification and incur performance penalties.
 ---
 
 ## ALTER MATERIALIZED VIEW (Continuous Aggregate) :community_function: [](continuous_aggregate-alter_view)
@@ -1831,8 +1831,8 @@ supplied should also be `timestamptz`).
 |Name|Description|
 |---|---|
 | `continuous_aggregate` | (REGCLASS) The continuous aggregate to refresh. |
-| `window_start` | Start of the window to refresh, has to be before `window_end`. |
-| `window_end` | End of the window to refresh, has to be after `window_start`. |
+| `window_start` | Start of the window to refresh, has to be before `window_end`. `NULL` is eqivalent to `MIN(timestamp)` of the hypertable. |
+| `window_end` | End of the window to refresh, has to be after `window_start`. `NULL` is eqivalent to `MAX(timestamp)` of the hypertable. |
 
 #### Sample Usage [](refresh_continuous_aggregate-examples)
 

--- a/tutorials/continuous-aggs-tutorial.md
+++ b/tutorials/continuous-aggs-tutorial.md
@@ -8,16 +8,17 @@ For instance if we want to find out the average of a column for each day in the
 dataset stored in a hypertable, we would run
 
 ``` sql
-SELECT time_bucket('1 day', time_dimension_column_name) bucket, avg(column_name), stddev(column_name)
+SELECT time_bucket('1 day', time_dimension_column_name) bucket,
+  avg(column_name), stddev(column_name)
 FROM hypertable
 GROUP BY bucket;
 ```
 
 However, performing this query as written requires scanning all the data within
-the table, which can be inefficient if this query is called frequently. A
-continuous aggregate view recomputes the query automatically at user specified
+the hypertable, which can be inefficient if this query is called frequently. A
+**continuous aggregate** recomputes the query automatically at user specified
 time intervals and materializes the results into a table. When the user
-queries the view, the system reads and processes the much smaller materialized
+queries the continuous aggregate, the system reads and processes the much smaller materialized
 table. This speeds up the query significantly. This is particularly useful when
 recomputing aggregates frequently for large data sets.
 
@@ -85,39 +86,48 @@ SELECT vendor_id, time_bucket('1h', pickup_datetime) as day,
 FROM rides
 GROUP BY vendor_id, time_bucket('1h', pickup_datetime);
 ```
-Everytime the query is run, the database recomputes the results for the query by
-scanning the entire table. With continuous aggregate queries, we have a way of
+Every time the query is run, the database recomputes the results for the query by
+scanning the entire table. With continuous aggregates, we have a way of
 telling TimescaleDB to cache the results and update them when the underlying
-data in the *rides* table is modified. Under the covers, TimescaleDB creates
-a **materialization table** where the result of this query is saved. The
-materialization table is updated at a **refresh interval** which is specified
- when the continuous aggregate query is created. For example, if we
-specify a refresh interval of 10 minutes, the continuous aggregate query
- checks the changes (inserts/updates/deletes) that were made to the *rides*
-table, recomputes the aggregates for the modified rows and updates the
-values in the materialization table.
+data in the *rides* table is modified. 
 
+Under the covers, TimescaleDB creates a **materialization table** where the result 
+of this query is saved. The materialization table is updated at a **schedule interval** 
+which is specified with the continuous aggregate policy. For example, if we
+specify a schedule interval of 30 minutes, the continuous aggregate 
+checks every 30 minutes for changes (inserts/updates/deletes) that were 
+made to the *rides* table, recomputes the aggregates for the modified rows 
+and updates the values in the materialization table.
 
-We use the `CREATE VIEW` statement and specify `timescaledb.continuous` in the
-`WITH` clause to create a continuous aggregate query. We use
-`timescaledb.refresh_interval` parameter to specify that we want to update the
-continuous aggregate query every 30 minutes.
+We use the `CREATE MATERIALIZED VIEW` statement and specify `timescaledb.continuous` in the
+`WITH` clause to create a continuous aggregate query. Then we use the  
+`add_continuous_aggregation_policy()` function to specify that we want to update the
+continuous aggregate view every 30 minutes.
+
+>:TIP:If you have a lot of historical data to aggregate into the view, consider using
+> the `WITH NO DATA` option as outlined in the [alternative approach](#with-no-data).
 
 ```sql
-CREATE VIEW cagg_rides_view WITH
-(timescaledb.continuous, timescaledb.refresh_interval = '30m')
+CREATE MATERIALIZED VIEW cagg_rides_view WITH
+  (timescaledb.continuous)
 AS
 SELECT vendor_id, time_bucket('1h', pickup_datetime) as day,
-     count(*) total_rides,
-     avg(fare_amount) avg_fare,
-     max(trip_distance) as max_trip_distance,
-     min(trip_distance) as min_trip_distance
+  count(*) total_rides,
+  avg(fare_amount) avg_fare,
+  max(trip_distance) as max_trip_distance,
+  min(trip_distance) as min_trip_distance
 FROM rides
 GROUP BY vendor_id, time_bucket('1h', pickup_datetime);
+
+SELECT add_continuous_aggregate_policy('cagg_rides_view', 
+  start_offset => INTERVAL '1 week',
+  end_offset   => INTERVAL '1 hour',
+  schedule_interval => INTERVAL '30 minutes');
 ```
 Note that a continuous aggregate query requires a group by clause with a
 `time_bucket` expression and the `time_bucket` expression uses the time dimension
 column of the *rides* hypertable.
+
 ```sql
 \d cagg_rides_view
                           View "public.cagg_rides_view"
@@ -131,55 +141,59 @@ column of the *rides* hypertable.
  min_trip_distance | numeric                     |           |          |
 ```
 
-We can view the metadata for the continuous aggregate in the
-**timescaledb_information.continuous_aggregates** view.
+We can view the metadata for the continuous aggregate by selecting information 
+from the **timescaledb_information.continuous_aggregates** view joined to the
+**timescaledb_information.jobs** view.
 
 ``` sql
-SELECT view_name, refresh_lag, refresh_interval, max_interval_per_job,
-       ignore_invalidation_older_than, materialization_hypertable
-FROM timescaledb_information.continuous_aggregates;
--[ RECORD 1 ]--------------+-------------------------------------------------
-view_name                      | cagg_rides_view
-refresh_lag                    | 02:00:00
-refresh_interval               | 00:30:00
-max_interval_per_job           | 20:00:00
-ignore_invalidation_older_than | 7 days
-materialization_hypertable     | _timescaledb_internal._materialized_hypertable_2
+SELECT view_name, schedule_interval, 
+  config ->> 'start_offset' as start_offset,
+  config ->> 'end_offset' as end_offset,
+  date_trunc('second',next_start::timestamp) as next_start,
+  materialization_hypertable_name
+FROM timescaledb_information.continuous_aggregates ca
+  INNER JOIN timescaledb_information.jobs j 
+    ON ca.materialization_hypertable_name = j.hypertable_name
+  WHERE view_name = 'cagg_rides_view';
+
+-[ RECORD 1 ]-------------------+---------------------------
+view_name                       | cagg_rides_view
+schedule_interval               | 00:30:00
+start_offset                    | 7 days
+end_offset                      | 01:00:00
+next_start                      | 2020-10-29 15:59:51
+materialization_hypertable_name | _materialized_hypertable_9
 ```
-The `refresh_interval` is set to 30 minutes. The computed aggregates are saved
-in the materialization table, `_timescaledb_internal._materialized_hypertable_2`.
 
-What are `refresh_lag` and `max_interval_per_job`? We use the
-`timescaledb.refresh_lag` parameter to indicate by how much does the continuous
- aggregate query lag behind the data in the *rides* table. For example, if we
-expect frequent updates to the *rides*  table for the current hour, we do not
-want to precompute the aggregates for that range. We would set the
-`refresh_lag = '1h'` to indicate that. (The default value is twice the
-bucket_width used by the `time_bucket` expression. This is the 2 hours shown for
-`refresh_lag` in the view output above). So the continuous aggregate will get
-refreshed every 30 minutes (`refresh_interval`) but will update the continuous
-aggregates only for the data that satisfies the condition:
-`time_bucket('1h', pickup_datetime) < max(pickup_time) - '1h'` (if the
-`refresh_lag` is set to 1 hour)
+As you can see from the result, the `schedule_interval` is set to 30 minutes. The
+computed aggregates are saved in the materialization table, 
+`_timescaledb_internal._materialized_hypertable_9`.
 
-The `timescaledb.max_interval_per_job` parameter is used when we want to limit
-the amount of data processed by an update of the continuous aggregate and use
-smaller or bigger batch sizes (the batching is done automatically by TimescaleDB).
-`timescaledb.max_interval_per_job` specifies the batch size.
+What are `start_offset` and `end_offset`? These intervals determine the window
+of time TimescaleDB will look at when refreshing the data in the continuous aggregate.
+`start_offset` determines the oldest timestamp in the hypertable that TimescaleDB 
+will look for changes to data in the underlying hypertable, while `end_offset` is the 
+most recent timestamp interval that will be considered.
 
-The parameters `refresh_lag` and `max_interval_per_job` can be
-specified while creating or altering a continuous aggregate. Refer to
-the documentation for the syntax.
+>:TIP:In TimescaleDB 1.x, `start_offset` was called `ignore_invalidation_oder_than` and
+>`end_offset` was called `refresh_lag`
 
-The `timescaledb.ignore_invalidation_older_than` parameter is used
-when you want to avoid updating a continuous aggregate when modifying
-(that is, inserting, updating, or deleting) older record. Setting this
-to, for example, "1 week" will ensure that any update for a record
-that is older than 1 week will not trigger an update of the continuous
-aggregate.
+For example, if we expect frequent updates to the *rides*  table for the current hour, we do not
+want to materialize the aggregates for that range. We would set the `end_offset = INTERVAL '1h'` 
+to indicate that. (If you don't specify an `end_offset` the default value is twice the
+bucket_width used by the `time_bucket` expression.) 
+
+So given the continuous aggregate policy that we created above, the continuous aggregate will get
+refreshed every 30 minutes (`schedule_interval`) but will update the continuous aggregates only 
+for the data that satisfies the condition:
+
+```sql
+time_bucket('1h', pickup_datetime) > max(pickup_time) - INTERVAL '7 days' 
+  AND time_bucket('1h', pickup_datetime) < max(pickup_time) - '1h'
+``` 
 
 ### 3. Queries using continuous aggregates
-We can use the continuous aggregate, just like any other view, in a `SELECT` query.
+We can use the continuous aggregate just like any other `VIEW` in a `SELECT` query.
 
 ``` sql
 SELECT vendor_id, day, total_rides FROM cagg_rides_view WHERE total_rides > 15000;
@@ -191,25 +205,31 @@ SELECT vendor_id, day, total_rides FROM cagg_rides_view WHERE total_rides > 1500
 
 ### 4. Statistics for continuous aggregates
 
-We can view information about the jobs that updated the continuous aggregates
-using the **timescaledb_information.continuous_aggregate_stats** view.
+We can view information about the jobs that update the continuous aggregate
+using the **timescaledb_information.job_stats** view.
 
 ``` sql
-SELECT * FROM timescaledb_information.continuous_aggregate_stats;
+SELECT * FROM timescaledb_information.job_stats js 
+WHERE job_id = (
+  SELECT job_id FROM timescaledb_information.jobs j 
+    INNER JOIN timescaledb_information.continuous_aggregates ca 
+    ON j.hypertable_name = ca.materialization_hypertable_name 
+  WHERE ca.view_name = 'cagg_rides_view'
+);
+
 -[ RECORD 1 ]----------+------------------------------
-view_name              | cagg_rides_view
-completed_threshold    | 2016-01-31 22:00:00
-invalidation_threshold | 2016-01-31 22:00:00
-job_id                 | 1000
-last_run_started_at    | 2019-04-25 10:48:08.15141-04
+hypertable_schema      | _timescaledb_internal
+hypertable_name        | _materialized_hypertable_9
+job_id                 | 1006
+last_run_started_at    | 2020-10-29 15:59:51.814305+00
+last_successful_finish | 2020-10-29 15:59:51.823749+00
 last_run_status        | Success
-job_status             | scheduled
-last_run_duration      | 00:00:00.042841
-next_scheduled_run     | 2019-04-25 11:18:08.194251-04
-total_runs             | 1
-total_successes        | 1
+job_status             | Scheduled
+last_run_duration      | 00:00:00.009444
+next_start             | 2020-10-29 16:29:51.823749+00
+total_runs             | 2
+total_successes        | 2
 total_failures         | 0
-total_crashes          | 0
 
 
 ---- fetch max pickup_datetime for comparison with completed_threshold ----
@@ -220,38 +240,90 @@ max | 2016-01-31 23:59:59
 ```
 
 The column `job_id` gives the id of the background worker that updates the continuous
-aggregate query. `next_scheduled_run` says when the next scheduled update
-will occur.  The `completed_threshold` shows that rows with
-`pickup_time` value < '2016-01-31 22:00:00' (from the *rides* table) were used
-to update the continuous aggregate. Since the `refresh_lag` is set to 2 hours,
-the completed threshold is 2 hours behind the maximum pickup_time in the  
-*rides* table.  After a job completes, the `invalidation_threshold` and
-`completed_threshold` will be the same. These values differ when a background
-job is running.
+aggregate. `next_start` says when the next scheduled update will occur. 
+`last_sucessful_finish` and `last_run_duration` allow you to see when the
+scheduled aggregate finished and how long it took to run.
 
+### 5. Update the Continuous Aggregate schedule
+Altering the schedule or parameters of a continuous aggregate policy is accomplished by
+first removing the existing policy and then creating a new updated policy with the
+desired settings.
 
-### 5. Alter and Refresh of continuous aggregates
-The parameters passed in the `WITH` clause can be modified using `ALTER VIEW`.  
-We can modify the `refresh_lag` to 1 hour using `ALTER VIEW`.
+To modify the policy that currently exists on the `cagg_rides_view` so that the `start_offset`
+is now equal to `1 month`, you would:
 
 ``` sql
-ALTER VIEW cagg_rides_view SET (timescaledb.refresh_lag='1h');
-ALTER VIEW
+SELECT remove_continuous_aggregate_policy('cagg_rides_view');
 
- SELECT view_name, refresh_lag, refresh_interval, max_interval_per_job, materialization_hypertable
-FROM timescaledb_information.continuous_aggregates;
--[ RECORD 1 ]--------------+-------------------------------------------------
-view_name                  | cagg_rides_view
-refresh_lag                | 01:00:00
-refresh_interval           | 00:30:00
-max_interval_per_job       | 20:00:00
-materialization_hypertable | _timescaledb_internal._materialized_hypertable_2
+SELECT add_continuous_aggregate_policy('cagg_rides_view', 
+  start_offset => interval '1 month',
+  end_offset   => INTERVAL '1 hour',
+  schedule_interval => INTERVAL '30 minutes');
+
+SELECT view_name, schedule_interval, 
+  config ->> 'start_offset' as start_offset,
+  config ->> 'end_offset' as end_offset,
+  date_trunc('second',next_start::timestamp) as next_start,
+  materialization_hypertable_name
+FROM timescaledb_information.continuous_aggregates ca
+  INNER JOIN timescaledb_information.jobs j 
+    ON ca.materialization_hypertable_name = j.hypertable_name
+  WHERE view_name = 'cagg_rides_view';
+
+-[ RECORD 1 ]-------------------+---------------------------
+view_name                       | cagg_rides_view
+schedule_interval               | 00:30:00
+start_offset                    | 1 mon
+end_offset                      | 01:00:00
+next_start                      | 2020-10-29 15:59:51
+materialization_hypertable_name | _materialized_hypertable_9
 ```
 
-You will find more details about the API in the [documentation][tsdb_doc].
+Notice that the `start_offset` is not set to `1 mon`.
+
+## Using `WITH NO DATA` when creating a Continuous Aggregate [](with-no-data)
+
+If you have a lot of historical data, we suggest creating the continuous aggregate
+using the `WITH NO DATA` parameter for the `CREATE MATERIALIZED VIEW` command. Doing 
+so will allow the continuous aggregate to be created instantly (you won't have to wait 
+for the data to be aggregated on creation!). Data will then begin to populate as the 
+continuous aggregate policy begins to run.
+
+**However**, only data newer than `start_offset` would begin to populate the continuous
+aggregate. If you have historical data that is older than the `start_offset` INTERVAL, 
+you need to manually refresh history up to the current `start_offset` to allow
+real-time queries to run efficiently.
+
+Using the example in **Step 2** above, if we had years worth of data, a better approach 
+to creating the continuous aggregate is shown in the SQL below which includes `WITH NO DATA`
+and specifically refreshes the history separate from the continuous aggregate refresh policy:
+
+```sql
+CREATE MATERIALIZED VIEW cagg_rides_view WITH
+  (timescaledb.continuous)
+AS
+SELECT vendor_id, time_bucket('1h', pickup_datetime) as day,
+  count(*) total_rides,
+  avg(fare_amount) avg_fare,
+  max(trip_distance) as max_trip_distance,
+  min(trip_distance) as min_trip_distance
+FROM rides
+GROUP BY vendor_id, time_bucket('1h', pickup_datetime)
+WITH NO DATA;
+
+SELECT add_continuous_aggregate_policy('cagg_rides_view', 
+  start_offset => INTERVAL '1 week',
+  end_offset   => INTERVAL '1 hour',
+  schedule_interval => INTERVAL '30 minutes');
+
+CALL refresh_continuous_aggregate('cagg_rides_view', NULL, localtimestamp - INTERVAL '1 week');
+```
+
+
+You will find more details about the Continuous Aggregate API in the [documentation][cagg_api].
 
 [hello_timescale]: /tutorials/tutorial-hello-timescale
 [nyc_data]: https://timescaledata.blob.core.windows.net/datasets/nyc_data.tar.gz
-[tsdb_doc]: https://docs.timescale.com/api
+[tsdb_doc]: https://docs.timescale.com/v2.0/api#continuous-aggregates
 [install-timescale]: /getting-started/installation
 


### PR DESCRIPTION
Updates to the Continuous Aggregate tutorial to work with 2.0. Please take note of the changes I made to the informational view queries to try and show the same/similar information. Fully open to updating them if we feel the need.

I also noticed that a few things in the API document hadn't been updated for the Materialized View change AND I updated the parameters of `refresh_continuous_aggregate()` to reflect what I learned about using `NULL` for the offsets if necessary. Not sure if we want to acknowledge that `NULL` is an option or not... but it was useful in one scenario with old data.