### PR TITLE
docs: fix typo of `postgresql.conf` parameter (`listen_addresses`)

### DIFF
--- a/tutorials/replication.md
+++ b/tutorials/replication.md
@@ -87,7 +87,7 @@ synchronous replication configurations.
 #### Asynchronous Replication with 1 Replica
 
 ```
-listen_address = "*"
+listen_addresses = '*'
 wal_level = replica
 max_wal_senders = 1
 max_replication_slots = 1


### PR DESCRIPTION
The name of the parameter `listen_address` that's given in the example configuration should actually be `listen_addresses` (see https://www.postgresql.org/docs/current/runtime-config-connection.html).