### PR TITLE
Updated Forge images and resize documentation; added Windows and other 2.0 references

### DIFF
--- a/getting-started/exploring-forge.md
+++ b/getting-started/exploring-forge.md
@@ -29,16 +29,15 @@ and, failing that, please [contact us][contact-timescale].
 <img class="main-content__illustration" src="https://assets.iobeam.com/images/docs/forge_images/timescale-forge-service-creation.png" alt="Set up a Timescale Forge service"/>
 
 1. First, supply your service name (e.g., `acmecorp-test` or `acmecorp-dev`).
-1. Next, choose your CPU and memory configuration, from (0.5 CPU, 2GB RAM) to (4 CPU, 16 GB RAM).
-1. Select your storage requirements, from 25 GB to 500 GB.  Note with TimescaleDB compression, this is typically equivalent to 400 GB to over 8 TB of uncompressed storage (although compression rates can vary based on your data).
+1. Next, choose your CPU and memory configuration, from (0.5 CPU, 2GB RAM) to (8 CPU, 32 GB RAM).
+1. Select your storage requirements, from 25 GB to 1 TB.  Note with TimescaleDB compression, this is typically equivalent to 400 GB to over 16 TB of uncompressed storage (although compression rates can vary based on your data).
 1. Note the estimated cost of running your chosen configuration. Feel free to [contact us][contact-timescale] if you would like to discuss pricing and configuration options best suited for your use case.
 1. Click 'Create service' once your configuration is complete.
 
-We'll be adding additional CPU and storage configurations in the future.  We'll
-also be adding the ability to quickly switch CPU configurations and storage
-options for your existing database with just a click, so you can scale with
-your usage needs.  For now, please [reach out][contact-timescale] if you need
-to reconfigure an existing service.
+>:TIP:Don't worry if too much about the size settings that you choose initially. With Timescale Forge,
+it's easy to modify both the compute (CPU/Memory) and storage associated with the service
+that you just created. As you get to know Timescale and how your data processing needs vary,
+it's easy to [right-size your service with a few clicks](#forge-resize)!
 
 After you select 'Create service', you will see confirmation of your service account and
 password information. You should save the information in this confirmation screen in 
@@ -93,6 +92,56 @@ You will have an unthrottled, 30-day free trial with Timescale Forge to
 continue to test your use case. Before the end of your trial, we encourage you 
 to add your credit card information. This will ensure a smooth transition after 
 your trial period concludes.
+
+## Resizing Compute and Storage in Timescale Forge [](forge-resize)
+
+Timescale Forge allows you to resize compute (CPU/RAM) and storage independently at any time. This is extremely
+useful when users have a need to increase storage (for instance) but not compute. The Timescale Forge 
+console makes this very easy to do for any service.
+
+Before you modify the compute or storage settings for a Forge Service, please note the following limitations
+and when a change to these settings will result in momentary downtime.
+
+**Storage**: Storage changes are applied with no downtime, typically available within a few seconds. Other
+things to note about storage changes:
+ * At the current time, storage can only be increased in size.
+ * Storage size changes can only be made once every six (6) hours.
+ * Storage can be modified in 25GB increments between 25GB-500GB, and then in 100GB increments between 500GB-1TB.
+
+**Compute**: Modifications to the compute settings of your service (up or down) can be applied at any time, however,
+please note the following:
+ * **_There will be momentary downtime_** while the compute settings are applied. In most cases, this downtime
+will be less than a minute.
+ * Because there will be an interruption to your service, you should plan accordingly to have the settings 
+ applied at an appropriate service window.
+
+### Step 1: View Service operation details 
+To modify the compute or storage of your Service, first select the Service that you want to modify. This
+will display the _service details_ which list four tabs across the top: Overview, Operations, Metrics, and Logs.
+
+Select **_Operations_**.
+
+<img class="main-content__illustration" src="https://assets.iobeam.com/images/docs/forge_images/timescale-forge-service-operations.png" alt="View Timescale Forge service operational information"/>
+
+### Step 2: Display the current Service Resources
+Under the Operations tab, you can perform the same **Basic** operations as before (Reset password, Pause service, Delete service).
+There is now a second, advanced section on the left labeled **Resources**. Selecting this option displays the current resource
+settings for the Service.
+
+<img class="main-content__illustration" src="https://assets.iobeam.com/images/docs/forge_images/timescale-forge-service-resources.png" alt="View Timescale Forge service resource information"/>
+
+### Step 3: Modify Service resources
+Once you have navigated to the current Service resources, it's easy to modify either the compute (CPU/Memory) or
+disk size. As you modify either setting, notice that the current and new hourly charges are displayed in real-time
+so that it's easy to verify how these changes will impact your costs.
+
+As noted above, changes to disk size will not cause any downtime, but size can only be increased at the current time, 
+and only once every six (6) hours. 
+
+When you're satisfied with the changes, click **Apply** (storage resizes only) or **Apply and Restart** (when modifying compute resources).
+
+<img class="main-content__illustration" src="https://assets.iobeam.com/images/docs/forge_images/timescale-forge-service-restart.png" alt="View Timescale Forge service apply resize"/>
+
 
 ### Summary
 

--- a/getting-started/exploring-forge.md
+++ b/getting-started/exploring-forge.md
@@ -36,7 +36,7 @@ and, failing that, please [contact us][contact-timescale].
 
 >:TIP:Don't worry if too much about the size settings that you choose initially. With Timescale Forge,
 it's easy to modify both the compute (CPU/Memory) and storage associated with the service
-that you just created. As you get to know Timescale and how your data processing needs vary,
+that you just created. As you get to know TimescaleDB and how your data processing needs vary,
 it's easy to [right-size your service with a few clicks](#forge-resize)!
 
 After you select 'Create service', you will see confirmation of your service account and
@@ -108,10 +108,10 @@ things to note about storage changes:
  * Storage size changes can only be made once every six (6) hours.
  * Storage can be modified in 25GB increments between 25GB-500GB, and then in 100GB increments between 500GB-1TB.
 
-**Compute**: Modifications to the compute settings of your service (up or down) can be applied at any time, however,
+**Compute**: Modifications to the compute size of your service (increases or decreases) can be applied at any time, however,
 please note the following:
  * **_There will be momentary downtime_** while the compute settings are applied. In most cases, this downtime
-will be less than a minute.
+will be less than 30 seconds.
  * Because there will be an interruption to your service, you should plan accordingly to have the settings 
  applied at an appropriate service window.
 

--- a/getting-started/installation-apt-debian.md
+++ b/getting-started/installation-apt-debian.md
@@ -43,7 +43,7 @@ sudo apt-get install timescaledb-2-postgresql-:pg_version:
 ```
 
 #### Upgrading from TimescaleDB 1.x
-If you are upgrading from TimescaleDB 1.x, the `apt` package will as to first
+If you are upgrading from TimescaleDB 1.x, the `apt` package will first
 uninstall the previous version of TimescaleDB and then install the latest TimescaleDB 2.0
 binaries. The feedback in your terminal should look similar to the following:
 

--- a/getting-started/installation-apt-debian.md
+++ b/getting-started/installation-apt-debian.md
@@ -63,7 +63,7 @@ After this operation, 1314 kB of additional disk space will be used.
 Do you want to continue? [Y/n]
 ```
 
-Once you confirm and install the newest binary package, you must still perform the
+Once you confirm and install the newest binary package, perform the
 EXTENSION update as discussed in [Updating Timescale to 2.0][update-tsdb-2].
 
 #### Configure your database

--- a/getting-started/installation-apt-debian.md
+++ b/getting-started/installation-apt-debian.md
@@ -64,7 +64,7 @@ Do you want to continue? [Y/n]
 ```
 
 Once you confirm and install the newest binary package, you must still perform the
-EXTENSION update as discussed in [Updating Timescale to 2.0][update-tsdb-2]
+EXTENSION update as discussed in [Updating Timescale to 2.0][update-tsdb-2].
 
 #### Configure your database
 
@@ -91,4 +91,4 @@ sudo service postgresql restart
 [contact]: https://www.timescale.com/contact
 [slack]: https://slack.timescale.com/
 [multi-node-basic]: /getting-started/setup-multi-node-basic
-[update-tsdb-2]: /update-timescaeldb/update-tsdb-2
+[update-tsdb-2]: /update-timescaledb/update-tsdb-2

--- a/getting-started/installation-apt-debian.md
+++ b/getting-started/installation-apt-debian.md
@@ -42,6 +42,30 @@ sudo apt-get update
 sudo apt-get install timescaledb-2-postgresql-:pg_version:
 ```
 
+#### Upgrading from TimescaleDB 1.x
+If you are upgrading from TimescaleDB 1.x, the `apt` package will as to first
+uninstall the previous version of TimescaleDB and then install the latest TimescaleDB 2.0
+binaries. The feedback in your terminal should look similar to the following:
+
+```bash
+Reading package lists... Done
+Building dependency tree       
+Reading state information... Done
+The following additional packages will be installed:
+  timescaledb-2-loader-postgresql-12
+The following packages will be REMOVED:
+  timescaledb-loader-postgresql-12 timescaledb-postgresql-12
+The following NEW packages will be installed:
+  timescaledb-2-loader-postgresql-12 timescaledb-2-postgresql-12
+0 upgraded, 2 newly installed, 2 to remove and 11 not upgraded.
+Need to get 953 kB of archives.
+After this operation, 1314 kB of additional disk space will be used.
+Do you want to continue? [Y/n]
+```
+
+Once you confirm and install the newest binary package, you must still perform the
+EXTENSION update as discussed in [Updating Timescale to 2.0][update-tsdb-2]
+
 #### Configure your database
 
 There are a [variety of settings that can be configured][config] for your
@@ -67,3 +91,4 @@ sudo service postgresql restart
 [contact]: https://www.timescale.com/contact
 [slack]: https://slack.timescale.com/
 [multi-node-basic]: /getting-started/setup-multi-node-basic
+[update-tsdb-2]: /update-timescaeldb/update-tsdb-2

--- a/getting-started/installation-apt-ubuntu.md
+++ b/getting-started/installation-apt-ubuntu.md
@@ -44,7 +44,7 @@ sudo apt install timescaledb-2-postgresql-:pg_version:
 ```
 
 #### Upgrading from TimescaleDB 1.x
-If you are upgrading from TimescaleDB 1.x, the `apt` package will as to first
+If you are upgrading from TimescaleDB 1.x, the `apt` package will first
 uninstall the previous version of TimescaleDB and then install the latest TimescaleDB 2.0
 binaries. The feedback in your terminal should look similar to the following:
 

--- a/getting-started/installation-apt-ubuntu.md
+++ b/getting-started/installation-apt-ubuntu.md
@@ -65,7 +65,7 @@ Do you want to continue? [Y/n]
 ```
 
 Once you confirm and install the newest binary package, you must still perform the
-EXTENSION update as discussed in [Updating Timescale to 2.0][update-tsdb-2]
+EXTENSION update as discussed in [Updating Timescale to 2.0][update-tsdb-2].
 
 #### Configure your database
 
@@ -93,4 +93,4 @@ sudo service postgresql restart
 [contact]: https://www.timescale.com/contact
 [slack]: https://slack.timescale.com/
 [multi-node-basic]: /getting-started/setup-multi-node-basic
-[update-tsdb-2]: /update-timescaeldb/update-tsdb-2
+[update-tsdb-2]: /update-timescaledb/update-tsdb-2

--- a/getting-started/installation-apt-ubuntu.md
+++ b/getting-started/installation-apt-ubuntu.md
@@ -43,6 +43,30 @@ sudo apt-get update
 sudo apt install timescaledb-2-postgresql-:pg_version:
 ```
 
+#### Upgrading from TimescaleDB 1.x
+If you are upgrading from TimescaleDB 1.x, the `apt` package will as to first
+uninstall the previous version of TimescaleDB and then install the latest TimescaleDB 2.0
+binaries. The feedback in your terminal should look similar to the following:
+
+```bash
+Reading package lists... Done
+Building dependency tree       
+Reading state information... Done
+The following additional packages will be installed:
+  timescaledb-2-loader-postgresql-12
+The following packages will be REMOVED:
+  timescaledb-loader-postgresql-12 timescaledb-postgresql-12
+The following NEW packages will be installed:
+  timescaledb-2-loader-postgresql-12 timescaledb-2-postgresql-12
+0 upgraded, 2 newly installed, 2 to remove and 11 not upgraded.
+Need to get 953 kB of archives.
+After this operation, 1314 kB of additional disk space will be used.
+Do you want to continue? [Y/n]
+```
+
+Once you confirm and install the newest binary package, you must still perform the
+EXTENSION update as discussed in [Updating Timescale to 2.0][update-tsdb-2]
+
 #### Configure your database
 
 There are a [variety of settings that can be configured][config] for your
@@ -69,3 +93,4 @@ sudo service postgresql restart
 [contact]: https://www.timescale.com/contact
 [slack]: https://slack.timescale.com/
 [multi-node-basic]: /getting-started/setup-multi-node-basic
+[update-tsdb-2]: /update-timescaeldb/update-tsdb-2

--- a/getting-started/installation-source-windows.md
+++ b/getting-started/installation-source-windows.md
@@ -66,7 +66,7 @@ Then, restart the PostgreSQL instance.
 
 #### Updating from TimescaleDB 1.x to 2.0
 Once the latest TimescaleDB 2.0 are installed, you can update the EXTENSION 
-in your database as discussed in [Updating Timescale to 2.0][update-tsdb-2]
+in your database as discussed in [Updating Timescale to 2.0][update-tsdb-2].
 
 
 >:TIP: Our standard binary releases are licensed under the Timescale License,
@@ -78,4 +78,4 @@ to `bootstrap`.
 [CMake]: https://cmake.org/
 [github-releases]: https://github.com/timescale/timescaledb/releases
 [github-timescale]: https://github.com/timescale/timescaledb
-[update-tsdb-2]: /update-timescaeldb/update-tsdb-2
+[update-tsdb-2]: /update-timescaledb/update-tsdb-2

--- a/getting-started/installation-source-windows.md
+++ b/getting-started/installation-source-windows.md
@@ -64,6 +64,11 @@ shared_preload_libraries = 'timescaledb'
 
 Then, restart the PostgreSQL instance.
 
+#### Updating from TimescaleDB 1.x to 2.0
+Once the latest TimescaleDB 2.0 are installed, you can update the EXTENSION 
+in your database as discussed in [Updating Timescale to 2.0][update-tsdb-2]
+
+
 >:TIP: Our standard binary releases are licensed under the Timescale License,
 which allows to use all our capabilities.
 To build a version of this software that contains
@@ -73,3 +78,4 @@ to `bootstrap`.
 [CMake]: https://cmake.org/
 [github-releases]: https://github.com/timescale/timescaledb/releases
 [github-timescale]: https://github.com/timescale/timescaledb
+[update-tsdb-2]: /update-timescaeldb/update-tsdb-2

--- a/getting-started/installation-windows.md
+++ b/getting-started/installation-windows.md
@@ -25,7 +25,7 @@ Go ahead and press ENTER to close the window
 
 #### Updating from TimescaleDB 1.x to 2.0
 Once the latest TimescaleDB 2.0 are installed, you can update the EXTENSION 
-in your database as discussed in [Updating Timescale to 2.0][update-tsdb-2]
+in your database as discussed in [Updating Timescale to 2.0][update-tsdb-2].
 
 #### Configure your database
 
@@ -53,4 +53,4 @@ to `bootstrap`.
 [config]: /getting-started/configuring
 [contact]: https://www.timescale.com/contact
 [slack]: https://slack.timescale.com/
-[update-tsdb-2]: /update-timescaeldb/update-tsdb-2
+[update-tsdb-2]: /update-timescaledb/update-tsdb-2

--- a/getting-started/installation-windows.md
+++ b/getting-started/installation-windows.md
@@ -1,8 +1,3 @@
->:WARNING: Our scaling out capabilities are currently in BETA and
-are not available through this installation method. For more information,
-please [contact us][contact] or join the #multinode channel in our 
-[community Slack][slack].
-
 ## Windows ZIP Installer [](installation-windows)
 
 **Note: TimescaleDB requires PostgreSQL 11 or 12.**
@@ -27,6 +22,10 @@ TimescaleDB installation completed succesfully.
 Press ENTER/Return key to close...
 ```
 Go ahead and press ENTER to close the window
+
+#### Updating from TimescaleDB 1.x to 2.0
+Once the latest TimescaleDB 2.0 are installed, you can update the EXTENSION 
+in your database as discussed in [Updating Timescale to 2.0][update-tsdb-2]
 
 #### Configure your database
 
@@ -54,3 +53,4 @@ to `bootstrap`.
 [config]: /getting-started/configuring
 [contact]: https://www.timescale.com/contact
 [slack]: https://slack.timescale.com/
+[update-tsdb-2]: /update-timescaeldb/update-tsdb-2

--- a/getting-started/installation-yum.md
+++ b/getting-started/installation-yum.md
@@ -55,6 +55,10 @@ sudo yum update -y
 sudo yum install -y timescaledb-2-postgresql-:pg_version:
 ```
 
+#### Upgrading from TimescaleDB 1.x
+If you are upgrading from TimescaleDB 1.x, the EXTENSION must be updated 
+in the database as discussed in [Updating Timescale to 2.0][update-tsdb-2]
+
 #### Configure your database
 
 There are a [variety of settings that can be configured][config] for your
@@ -81,3 +85,4 @@ refer to your distribution for how to restart services.
 [contact]: https://www.timescale.com/contact
 [slack]: https://slack.timescale.com/
 [multi-node-basic]: /getting-started/setup-multi-node-basic
+[update-tsdb-2]: /update-timescaeldb/update-tsdb-2

--- a/getting-started/installation-yum.md
+++ b/getting-started/installation-yum.md
@@ -57,7 +57,7 @@ sudo yum install -y timescaledb-2-postgresql-:pg_version:
 
 #### Upgrading from TimescaleDB 1.x
 If you are upgrading from TimescaleDB 1.x, the EXTENSION must be updated 
-in the database as discussed in [Updating Timescale to 2.0][update-tsdb-2]
+in the database as discussed in [Updating Timescale to 2.0][update-tsdb-2].
 
 #### Configure your database
 
@@ -85,4 +85,4 @@ refer to your distribution for how to restart services.
 [contact]: https://www.timescale.com/contact
 [slack]: https://slack.timescale.com/
 [multi-node-basic]: /getting-started/setup-multi-node-basic
-[update-tsdb-2]: /update-timescaeldb/update-tsdb-2
+[update-tsdb-2]: /update-timescaledb/update-tsdb-2

--- a/page-index/page-index.js
+++ b/page-index/page-index.js
@@ -122,7 +122,23 @@ const pageIndex = [
                 href: "installation-source",
               },
             ],
-          },
+          }, {
+            Title: "Windows",
+            type: DIRECTORY,
+            href: "windows",
+            src: "//assets.iobeam.com/images/docs/Windows_logo_-_2012.svg",
+            children: [
+                {
+                    Title: "Installer (.zip)",
+                    type: NON_MENU_PAGE,
+                    href: "installation-windows"
+                }, {
+                    Title: "Source",
+                    type: NON_MENU_PAGE,
+                    href: "installation-source-windows"
+                }
+            ]
+        },
         ],
       },
       {


### PR DESCRIPTION
Added updated images to Forge documentation based on the new UI and a section that discusses resizing.

Added link back to Install page to show Windows and added text on each install page to reference updating to 2.0 via the separate document.
