### PR TITLE
Set timescaledb.max_background_workers with timescaledb-tune

### DIFF
--- a/getting-started/configuring.md
+++ b/getting-started/configuring.md
@@ -102,13 +102,20 @@ workers you allocate here will run background jobs when needed.
 For larger queries, PostgreSQL automatically uses parallel workers if
 they are available. To configure this use the `max_parallel_workers` setting.
 Increasing this setting will improve query performance for
-larger queries.  Smaller queries may not trigger parallel workers.
+larger queries. Smaller queries may not trigger parallel workers. By default,
+this setting corresponds to the number of CPUs available. Use the `--cpus` flag
+or the `TS_TUNE_NUM_CPUS` docker environment variable to change it.
 
 Finally, you must configure `max_worker_processes` to be at least the sum of
 `timescaledb.max_background_workers` and `max_parallel_workers`.
 `max_worker_processes` is the total pool of workers available to both
 background and parallel workers (as well as a handful of built-in PostgreSQL
 workers).
+
+By default, `timescaledb-tune` sets `timescaledb.max_background_workers` to 8.
+In order to change this setting, use the `--max-bg-workers` flag or the
+`TS_TUNE_MAX_BG_WORKERS` docker environment variable. The `max_worker_processes`
+setting will automatically be adjusted as well.
 
 ### Disk-write settings [](disk-write)
 
@@ -162,7 +169,7 @@ review the official PostgreSQL documentation on
 ## TimescaleDB configuration and tuning [](timescaledb-config)
 
 Just as you can tune settings in PostgreSQL, TimescaleDB provides a number of configuration
-settings that may be useful to your specific installation and performance needs. These can 
+settings that may be useful to your specific installation and performance needs. These can
 also be set within the `postgresql.conf` file or as command-line parameters
 when starting PostgreSQL.
 


### PR DESCRIPTION
Fixes [timescaledb #1789](https://github.com/timescale/timescaledb/issues/1789)

Pending on [timescaledb-tune #73 ](https://github.com/timescale/timescaledb-tune/pull/73)

Pending on [timescaledb-docker #131](https://github.com/timescale/timescaledb-docker/pull/131)