### PR TITLE
Remove codeowners from 1.7 branch

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,1 @@
 # This file is to set repo owners
-* @solugebefola @svenklemm @mfreed


### PR DESCRIPTION
This removes CODEOWNERS from v1.7.4 branch so that PRs directly to branch can use any review to merge