### PR TITLE
Add hypertable to cagg information view

### DIFF
--- a/api.md
+++ b/api.md
@@ -3050,6 +3050,8 @@ Get metadata and settings information for continuous aggregates.
 
 |Name|Description|
 |---|---|
+|`hypertable_schema` | (NAME) Schema of the hypertable from the continuous aggregate view|
+|`hypertable_name` | (NAME) Name of the hypertable from the continuous aggregate view|
 |`view_schema` | (NAME) Schema for continuous aggregate view |
 |`view_name` | (NAME) User supplied name for continuous aggregate view |
 |`view_owner` | (NAME) Owner of the continuous aggregate view|
@@ -3063,6 +3065,8 @@ Get metadata and settings information for continuous aggregates.
 SELECT * FROM timescaledb_information.continuous_aggregates;
 
 -[ RECORD 1 ]---------------------+-------------------------------------------------
+hypertable_schema                 | public
+hypertable_name                   | foo
 view_schema                       | public 
 view_name                         | contagg_view
 view_owner                        | postgres

--- a/release-notes/changes-in-timescaledb-2.md
+++ b/release-notes/changes-in-timescaledb-2.md
@@ -346,15 +346,15 @@ BEGIN
     INTO STRICT drop_after;
   SELECT jsonb_object_field_text(config, 'hypertable')::regclass
     INTO STRICT hypertable;
-  BEGIN
-    SELECT _timescaledb_internal.refresh_continuous_aggregate(cagg, 
-        show_chunks(older_than => drop_after))
-    FROM _timescaledb_catalog.continuous_agg cagg, _timescaledb_catalog.hypertable hyper
-    WHERE cagg.raw_hypertable_id = hyper.id AND 
-      format('%I.%I', hyper.schema_name, hyper.table_name)::regclass = hypertable;
+
+  BEGIN;
+  SELECT _timescaledb_internal.refresh_continuous_aggregate(cagg, 
+      show_chunks(older_than => drop_after))
+  FROM timescaledb_information.continuous_aggregates
+  WHERE format('%I.%I', hypertable_schema, hypertable_name)::regclass = hypertable;
 
     SELECT drop_chunks(hypertable, older_than => drop_after);
-  END;
+  COMMIT;
 END
 $$;
 


### PR DESCRIPTION
Schema and name of the hypertable from the continuous aggregate view
were added to the information view about continuous aggregates. Thus
it is not necessary to join internal catalog tables to get the
continuous aggregate's hypertable.
