### PR TITLE
Timescale Forge changes to reflect new settings feature, resize and some distributed hypertable language

### DIFF
--- a/getting-started/exploring-forge.md
+++ b/getting-started/exploring-forge.md
@@ -31,8 +31,8 @@ and, failing that, please [contact us][contact-timescale].
 1. First, supply your service name (e.g., `acmecorp-test` or `acmecorp-dev`).
 1. Next, choose your CPU and memory configuration, from (0.5 CPU, 2GB RAM) to 
 (8 CPU, 32 GB RAM).
-1. Select your storage requirements, from 25 GB to 1 TB.  Note with TimescaleDB 
-compression, this is typically equivalent to 400 GB to over 16 TB of uncompressed 
+1. Select your storage requirements, from 25 GB to 1 TB.  Note that with TimescaleDB 
+compression, this is typically equivalent to 400 GB to 16+ TB of uncompressed 
 storage (although compression rates can vary based on your data).
 1. Note the estimated cost of running your chosen configuration. Feel free to 
 [contact us][contact-timescale] if you would like to discuss pricing and 

--- a/getting-started/exploring-forge.md
+++ b/getting-started/exploring-forge.md
@@ -29,9 +29,14 @@ and, failing that, please [contact us][contact-timescale].
 <img class="main-content__illustration" src="https://assets.iobeam.com/images/docs/forge_images/timescale-forge-service-creation.png" alt="Set up a Timescale Forge service"/>
 
 1. First, supply your service name (e.g., `acmecorp-test` or `acmecorp-dev`).
-1. Next, choose your CPU and memory configuration, from (0.5 CPU, 2GB RAM) to (8 CPU, 32 GB RAM).
-1. Select your storage requirements, from 25 GB to 1 TB.  Note with TimescaleDB compression, this is typically equivalent to 400 GB to over 16 TB of uncompressed storage (although compression rates can vary based on your data).
-1. Note the estimated cost of running your chosen configuration. Feel free to [contact us][contact-timescale] if you would like to discuss pricing and configuration options best suited for your use case.
+1. Next, choose your CPU and memory configuration, from (0.5 CPU, 2GB RAM) to 
+(8 CPU, 32 GB RAM).
+1. Select your storage requirements, from 25 GB to 1 TB.  Note with TimescaleDB 
+compression, this is typically equivalent to 400 GB to over 16 TB of uncompressed 
+storage (although compression rates can vary based on your data).
+1. Note the estimated cost of running your chosen configuration. Feel free to 
+[contact us][contact-timescale] if you would like to discuss pricing and 
+configuration options best suited for your use case.
 1. Click 'Create service' once your configuration is complete.
 
 >:TIP:Don't worry if too much about the size settings that you choose initially. With Timescale Forge,
@@ -93,56 +98,6 @@ continue to test your use case. Before the end of your trial, we encourage you
 to add your credit card information. This will ensure a smooth transition after 
 your trial period concludes.
 
-## Resizing Compute and Storage in Timescale Forge [](forge-resize)
-
-Timescale Forge allows you to resize compute (CPU/RAM) and storage independently at any time. This is extremely
-useful when users have a need to increase storage (for instance) but not compute. The Timescale Forge 
-console makes this very easy to do for any service.
-
-Before you modify the compute or storage settings for a Forge Service, please note the following limitations
-and when a change to these settings will result in momentary downtime.
-
-**Storage**: Storage changes are applied with no downtime, typically available within a few seconds. Other
-things to note about storage changes:
- * At the current time, storage can only be increased in size.
- * Storage size changes can only be made once every six (6) hours.
- * Storage can be modified in 25GB increments between 25GB-500GB, and then in 100GB increments between 500GB-1TB.
-
-**Compute**: Modifications to the compute size of your service (increases or decreases) can be applied at any time, however,
-please note the following:
- * **_There will be momentary downtime_** while the compute settings are applied. In most cases, this downtime
-will be less than 30 seconds.
- * Because there will be an interruption to your service, you should plan accordingly to have the settings 
- applied at an appropriate service window.
-
-### Step 1: View Service operation details 
-To modify the compute or storage of your Service, first select the Service that you want to modify. This
-will display the _service details_ which list four tabs across the top: Overview, Operations, Metrics, and Logs.
-
-Select **_Operations_**.
-
-<img class="main-content__illustration" src="https://assets.iobeam.com/images/docs/forge_images/timescale-forge-service-operations.png" alt="View Timescale Forge service operational information"/>
-
-### Step 2: Display the current Service Resources
-Under the Operations tab, you can perform the same **Basic** operations as before (Reset password, Pause service, Delete service).
-There is now a second, advanced section on the left labeled **Resources**. Selecting this option displays the current resource
-settings for the Service.
-
-<img class="main-content__illustration" src="https://assets.iobeam.com/images/docs/forge_images/timescale-forge-service-resources.png" alt="View Timescale Forge service resource information"/>
-
-### Step 3: Modify Service resources
-Once you have navigated to the current Service resources, it's easy to modify either the compute (CPU/Memory) or
-disk size. As you modify either setting, notice that the current and new hourly charges are displayed in real-time
-so that it's easy to verify how these changes will impact your costs.
-
-As noted above, changes to disk size will not cause any downtime, but size can only be increased at the current time, 
-and only once every six (6) hours. 
-
-When you're satisfied with the changes, click **Apply** (storage resizes only) or **Apply and Restart** (when modifying compute resources).
-
-<img class="main-content__illustration" src="https://assets.iobeam.com/images/docs/forge_images/timescale-forge-service-restart.png" alt="View Timescale Forge service apply resize"/>
-
-
 ### Summary
 
 We’re excited to play a small part in helping you build a best-in-class 
@@ -151,6 +106,15 @@ feel free to [join our community Slack group][slack-info]
 or [contact us][contact-timescale] directly.
 
 Now, it's time to forge!
+
+## Advanced configuration and Multi-node setup
+Timescale Forge is a versatile hosting service that provides a growing list of 
+advanced features for your PostgreSQL and time-series data workloads.
+
+Please see additional documentation on how to:
+ * [Resize compute and storage][resize] at any time!
+ * [Customize your database configuration][configuration] easily!
+ * [Create a TimescaleDB multi-node cluster][multi-node] in Timescale Forge!
 
 [forge-signup]: https://forge.timescale.com
 [billing-info]: /forge/managing-billing-payments
@@ -163,3 +127,6 @@ Now, it's time to forge!
 [time-bucket-info]: https://docs.timescale.com/latest/using-timescaledb/reading-data#time-bucket
 [gap-filling-info]: https://docs.timescale.com/latest/using-timescaledb/reading-data#gap-filling
 [aggregates-info]: https://docs.timescale.com/latest/tutorials/continuous-aggs-tutorial
+[resize]: /getting-started/exploring-forge/forge-resize
+[configuration]: /getting-started/exploring-forge/forge-configuration
+[multi-node]: /getting-started/exploring-forge/forge-multi-node

--- a/getting-started/forge-configuration.md
+++ b/getting-started/forge-configuration.md
@@ -8,11 +8,10 @@ the most essential values are set to reflect the size of the new Service.
 
 There are times, however, when your specific workload may require tuning some of
 the many available TimescaleDB and PostgreSQL parameters. By providing the ability
-to tune various runtime settings, Timescale Forge provides a lot of flexibility
-in providing the balance and flexibility you need when running your workloads
+to tune various runtime settings, Timescale Forge provides the balance and flexibility you need when running your workloads
 in our hosted environment.
 
-**Note**: Modifications of most parameters can be applied without restarting
+>:WARNING: Modifications of most parameters can be applied without restarting
 the Timescale Forge Service. However, as when modifying the compute resources
 of a running Service, some settings will require that a restart be performed,
 resulting in some brief downtime (usually about 30 seconds).
@@ -52,7 +51,7 @@ dialog will be displayed which lists the parameters that will be modified. Click
 
 ## Configuring Advanced Parameters
 It is also possible to configure a wide variety of Service database parameters
-but toggling the **Show advanced parameters** toggle in the upper-right corner
+by flipping the **Show advanced parameters** toggle in the upper-right corner
 of the **Settings** tab.
 
 <img class="main-content__illustration" src="https://assets.iobeam.com/images/docs/forge_images/timescale-forge-service-settings-advanced.png" alt="View Timescale Forge service configuration changes confirmation dialog"/>

--- a/getting-started/forge-configuration.md
+++ b/getting-started/forge-configuration.md
@@ -49,7 +49,7 @@ dialog will be displayed which lists the parameters that will be modified. Click
 <img class="main-content__illustration" src="https://assets.iobeam.com/images/docs/forge_images/timescale-forge-service-settings-confirm.png" alt="View Timescale Forge service configuration changes confirmation dialog"/>
 
 
-## Configuring Advanced Parameters
+## Configuring Advanced Parameters [](advanced-parameters)
 It is also possible to configure a wide variety of Service database parameters
 by flipping the **Show advanced parameters** toggle in the upper-right corner
 of the **Settings** tab.

--- a/getting-started/forge-configuration.md
+++ b/getting-started/forge-configuration.md
@@ -1,4 +1,4 @@
-## Customize database configuration in Timescale Forge [](forge-configuration)
+# Customize database configuration in Timescale Forge
 
 Timescale Forge allows you to customize many TimescaleDB and PostgreSQL configuration
 options for each Service individually. Most configuration values for a Service
@@ -16,7 +16,7 @@ the Timescale Forge Service. However, as when modifying the compute resources
 of a running Service, some settings will require that a restart be performed,
 resulting in some brief downtime (usually about 30 seconds).
 
-### Step 1: View Service operation details 
+## Step 1: View Service operation details  [](service-details)
 To modify configuration parameters, first select the Service that 
 you want to modify. This will display the _service details_ which list tabs
 across the top: Overview, Operations, Metrics, Logs, and Settings.
@@ -25,7 +25,7 @@ Select **_Settings_**.
 
 <img class="main-content__illustration" src="https://assets.iobeam.com/images/docs/forge_images/timescale-forge-service-settings-basic.png" alt="View Timescale Forge service operational information"/>
 
-### Step 2: Modify basic parameters
+## Step 2: Modify basic parameters [](basic-parameters)
 Under the Settings tab, you can modify a limited set of the parameters that are
 most often modified in a TimescaleDB or PostgreSQL instance. To modify a 
 configured value, simply click into on the **_value_** that you would like to
@@ -34,7 +34,7 @@ outside of that field will save the value to be applied.
 
 <img class="main-content__illustration" src="https://assets.iobeam.com/images/docs/forge_images/timescale-forge-service-settings-modify.png" alt="View Timescale Forge service settings modification"/>
 
-### Step 3: Apply configuration changes
+## Step 3: Apply configuration changes [](apply-changes)
 Once you have modified the basic configuration parameters that you would like to
 change, click the **Apply Changes** button. For some changes, such as `timescaledb.max_background_workers`
 (pictured below), the Service needs to be restarted. Therefore, the

--- a/getting-started/forge-configuration.md
+++ b/getting-started/forge-configuration.md
@@ -1,0 +1,68 @@
+## Customize database configuration in Timescale Forge [](forge-configuration)
+
+Timescale Forge allows you to customize many TimescaleDB and PostgreSQL configuration
+options for each Service individually. Most configuration values for a Service
+are initially set in accordance with best practices given the compute and storage
+settings of the Service. Any time you increase or decrease the compute for a Service
+the most essential values are set to reflect the size of the new Service.
+
+There are times, however, when your specific workload may require tuning some of
+the many available TimescaleDB and PostgreSQL parameters. By providing the ability
+to tune various runtime settings, Timescale Forge provides a lot of flexibility
+in providing the balance and flexibility you need when running your workloads
+in our hosted environment.
+
+**Note**: Modifications of most parameters can be applied without restarting
+the Timescale Forge Service. However, as when modifying the compute resources
+of a running Service, some settings will require that a restart be performed,
+resulting in some brief downtime (usually about 30 seconds).
+
+### Step 1: View Service operation details 
+To modify configuration parameters, first select the Service that 
+you want to modify. This will display the _service details_ which list tabs
+across the top: Overview, Operations, Metrics, Logs, and Settings.
+
+Select **_Settings_**.
+
+<img class="main-content__illustration" src="https://assets.iobeam.com/images/docs/forge_images/timescale-forge-service-settings-basic.png" alt="View Timescale Forge service operational information"/>
+
+### Step 2: Modify basic parameters
+Under the Settings tab, you can modify a limited set of the parameters that are
+most often modified in a TimescaleDB or PostgreSQL instance. To modify a 
+configured value, simply click into on the **_value_** that you would like to
+change. This will reveal an editable field to apply your change. Clicking anywhere
+outside of that field will save the value to be applied.
+
+<img class="main-content__illustration" src="https://assets.iobeam.com/images/docs/forge_images/timescale-forge-service-settings-modify.png" alt="View Timescale Forge service settings modification"/>
+
+### Step 3: Apply configuration changes
+Once you have modified the basic configuration parameters that you would like to
+change, click the **Apply Changes** button. For some changes, such as `timescaledb.max_background_workers`
+(pictured below), the Service needs to be restarted. Therefore, the
+button will read **Restart and apply changes**.
+
+<img class="main-content__illustration" src="https://assets.iobeam.com/images/docs/forge_images/timescale-forge-service-settings-apply.png" alt="View Timescale Forge service apply settings parameter changes"/>
+
+Regardless of whether the Service needs to be restarted or not, a confirmation
+dialog will be displayed which lists the parameters that will be modified. Click
+**Confirm** to apply the changes (and restart if necessary).
+
+<img class="main-content__illustration" src="https://assets.iobeam.com/images/docs/forge_images/timescale-forge-service-settings-confirm.png" alt="View Timescale Forge service configuration changes confirmation dialog"/>
+
+
+## Configuring Advanced Parameters
+It is also possible to configure a wide variety of Service database parameters
+but toggling the **Show advanced parameters** toggle in the upper-right corner
+of the **Settings** tab.
+
+<img class="main-content__illustration" src="https://assets.iobeam.com/images/docs/forge_images/timescale-forge-service-settings-advanced.png" alt="View Timescale Forge service configuration changes confirmation dialog"/>
+
+Once toggled, a scrollable (and searchable) list of configurable parameters will
+be displayed.
+
+<img class="main-content__illustration" src="https://assets.iobeam.com/images/docs/forge_images/timescale-forge-service-settings-advanced-search.png" alt="View Timescale Forge service configuration changes confirmation dialog"/>
+
+As with the basic database configuration parameters, any changes will be highlighted
+and the **Apply changes** (or **Restart and apply changes**) button will be
+available to click, prompting you to confirm any changes before the Service is
+modified.

--- a/getting-started/forge-resize.md
+++ b/getting-started/forge-resize.md
@@ -31,7 +31,7 @@ Select **_Operations_**.
 
 <img class="main-content__illustration" src="https://assets.iobeam.com/images/docs/forge_images/timescale-forge-service-operations.png" alt="View Timescale Forge service operational information"/>
 
-### Step 2: Display the current Service Resources
+## Step 2: Display the current Service Resources [](service-resources)
 Under the Operations tab, you can perform the same **Basic** operations as before 
 (Reset password, Pause service, Delete service). There is now a second, advanced
 section on the left labeled **Resources**. Selecting this option displays the 
@@ -39,7 +39,7 @@ current resource settings for the Service.
 
 <img class="main-content__illustration" src="https://assets.iobeam.com/images/docs/forge_images/timescale-forge-service-resources.png" alt="View Timescale Forge service resource information"/>
 
-### Step 3: Modify Service resources
+## Step 3: Modify Service resources [](modify-resources)
 Once you have navigated to the current Service resources, it's easy to modify 
 either the compute (CPU/Memory) or disk size. As you modify either setting, 
 notice that the current and new hourly charges are displayed in real-time

--- a/getting-started/forge-resize.md
+++ b/getting-started/forge-resize.md
@@ -1,4 +1,4 @@
-## Resizing Compute and Storage in Timescale Forge [](forge-resize)
+# Resizing Compute and Storage in Timescale Forge
 
 Timescale Forge allows you to resize compute (CPU/RAM) and storage independently 
 at any time. This is extremely useful when users have a need to increase storage 
@@ -10,7 +10,7 @@ note the following limitations and when a change to these settings will result i
 
 **Storage**: Storage changes are applied with no downtime, typically available 
 within a few seconds. Other things to note about storage changes:
- * At the current time, storage can only be increased in size.
+ * At the current time, storage can only be _increased_ in size.
  * Storage size changes can only be made once every six (6) hours.
  * Storage can be modified in 25GB increments between 25GB-500GB, and then in 
  100GB increments between 500GB-1TB.
@@ -20,9 +20,9 @@ decreases) can be applied at any time, however, please note the following:
  * **_There will be momentary downtime_** while the compute settings are applied. 
  In most cases, this downtime will be less than 30 seconds.
  * Because there will be an interruption to your service, you should plan 
- accordingly to have the settings  applied at an appropriate service window.
+ accordingly to have the settings applied at an appropriate service window.
 
-### Step 1: View Service operation details 
+## Step 1: View Service operation details [](service-details)
 To modify the compute or storage of your Service, first select the Service that 
 you want to modify. This will display the _service details_ which list four tabs
 across the top: Overview, Operations, Metrics, and Logs.
@@ -45,8 +45,9 @@ either the compute (CPU/Memory) or disk size. As you modify either setting,
 notice that the current and new hourly charges are displayed in real-time
 so that it's easy to verify how these changes will impact your costs.
 
-As noted above, changes to disk size will not cause any downtime, but size can 
-only be increased at the current time, and only once every six (6) hours. 
+As noted above, changes to disk size will not cause any downtime.  However,
+the platform currently only supports _increasing_ disk size (not decreasing it), 
+and you can increase disk size once every six (6) hours. 
 
 When you're satisfied with the changes, click **Apply** (storage resizes only) or **Apply and Restart** (when modifying compute resources).
 

--- a/getting-started/forge-resize.md
+++ b/getting-started/forge-resize.md
@@ -1,0 +1,53 @@
+## Resizing Compute and Storage in Timescale Forge [](forge-resize)
+
+Timescale Forge allows you to resize compute (CPU/RAM) and storage independently 
+at any time. This is extremely useful when users have a need to increase storage 
+(for instance) but not compute. The Timescale Forge console makes this very easy 
+to do for any service.
+
+Before you modify the compute or storage settings for a Forge Service, please 
+note the following limitations and when a change to these settings will result in momentary downtime.
+
+**Storage**: Storage changes are applied with no downtime, typically available 
+within a few seconds. Other things to note about storage changes:
+ * At the current time, storage can only be increased in size.
+ * Storage size changes can only be made once every six (6) hours.
+ * Storage can be modified in 25GB increments between 25GB-500GB, and then in 
+ 100GB increments between 500GB-1TB.
+
+**Compute**: Modifications to the compute size of your service (increases or 
+decreases) can be applied at any time, however, please note the following:
+ * **_There will be momentary downtime_** while the compute settings are applied. 
+ In most cases, this downtime will be less than 30 seconds.
+ * Because there will be an interruption to your service, you should plan 
+ accordingly to have the settings  applied at an appropriate service window.
+
+### Step 1: View Service operation details 
+To modify the compute or storage of your Service, first select the Service that 
+you want to modify. This will display the _service details_ which list four tabs
+across the top: Overview, Operations, Metrics, and Logs.
+
+Select **_Operations_**.
+
+<img class="main-content__illustration" src="https://assets.iobeam.com/images/docs/forge_images/timescale-forge-service-operations.png" alt="View Timescale Forge service operational information"/>
+
+### Step 2: Display the current Service Resources
+Under the Operations tab, you can perform the same **Basic** operations as before 
+(Reset password, Pause service, Delete service). There is now a second, advanced
+section on the left labeled **Resources**. Selecting this option displays the 
+current resource settings for the Service.
+
+<img class="main-content__illustration" src="https://assets.iobeam.com/images/docs/forge_images/timescale-forge-service-resources.png" alt="View Timescale Forge service resource information"/>
+
+### Step 3: Modify Service resources
+Once you have navigated to the current Service resources, it's easy to modify 
+either the compute (CPU/Memory) or disk size. As you modify either setting, 
+notice that the current and new hourly charges are displayed in real-time
+so that it's easy to verify how these changes will impact your costs.
+
+As noted above, changes to disk size will not cause any downtime, but size can 
+only be increased at the current time, and only once every six (6) hours. 
+
+When you're satisfied with the changes, click **Apply** (storage resizes only) or **Apply and Restart** (when modifying compute resources).
+
+<img class="main-content__illustration" src="https://assets.iobeam.com/images/docs/forge_images/timescale-forge-service-restart.png" alt="View Timescale Forge service apply resize"/>

--- a/page-index/page-index.js
+++ b/page-index/page-index.js
@@ -198,6 +198,16 @@ const pageIndex = [
         href: "exploring-forge",
         children: [
           {
+            Title: "Resize compute and storage",
+            type: PAGE,
+            href: "forge-resize",
+          },
+          {
+            Title: "Customize database configuration",
+            type: PAGE,
+            href: "forge-configuration",
+          },
+          {
             Title: "Multi-node setup",
             type: PAGE,
             href: "forge-multi-node",

--- a/using-timescaledb/distributed-hypertables.md
+++ b/using-timescaledb/distributed-hypertables.md
@@ -30,11 +30,12 @@ if the roles involved exist identically on all data nodes. Further,
 joins between a local table and a distributed hypertable requires
 fetching the raw data from data nodes and performing the join locally.
 
->:WARNING: Distributed hypertables are not yet recommended for
-production use. For more information, please review the current
-[limitations][distributed-hypertable-limitations]. You can also
-[contact us][contact] or join the #multinode channel in our [community
-Slack][slack].
+>:WARNING: Distributed hypertables currently have some limitations when 
+compared to non-distributed hypertables. Before creating a distributed hypertable
+for production workloads, please review our 
+[limitations][distributed-hypertable-limitations] document to ensure that your
+use case will work as expected. You can also [contact us][contact] or join the 
+#multinode channel in our [community Slack][slack].
 
 ## Creating a Distributed Hypertable [](create)
 


### PR DESCRIPTION
Reorganized the tree around Timescale Forge to create a new 
'Customize database configuration' page and separate out the 'Resize compute
and storage' page.

Also modified the "warning" about distributed hypertable limitations on
that documentation page.

