### PR TITLE
Internal hostname for Forge multi-node and updated anchor tags

### DIFF
--- a/getting-started/exploring-forge.md
+++ b/getting-started/exploring-forge.md
@@ -7,7 +7,7 @@ start and less expensive to operate.
 This tutorial will walk you through setting up your Timescale Forge account and
 completing your first tutorial project.
 
-### Step 1: Create a Timescale Forge account
+### Step 1: Create a Timescale Forge account [](step1-create-account)
 
 Sign up for Timescale Forge by visiting [forge.timescale.com][forge-signup].
 
@@ -19,7 +19,7 @@ You will need to confirm your account by clicking the link you receive via
 email. If you do not receive this link, please first check your spam folder 
 and, failing that, please [contact us][contact-timescale].
 
-### Step 2: Create your first service
+### Step 2: Create your first service [](step2-create-service)
 
  After you complete account verification, you can visit the 
  [Timescale Forge console][forge-console] and login with your credentials.
@@ -66,7 +66,7 @@ a service altogether.
 
 <img class="main-content__illustration" src="https://assets.iobeam.com/images/docs/forge_images/timescale-forge-service-details.png" alt="View Timescale Forge service information"/>
 
-### Step 3: Complete your first tutorial
+### Step 3: Complete your first tutorial [](step3-tutorial)
 
 Congratulations! You are now up and running with Timescale Forge. In order to
 familiarize yourself with the features and capabilities of the product, we

--- a/getting-started/forge-configuration.md
+++ b/getting-started/forge-configuration.md
@@ -16,7 +16,7 @@ the Timescale Forge Service. However, as when modifying the compute resources
 of a running Service, some settings will require that a restart be performed,
 resulting in some brief downtime (usually about 30 seconds).
 
-## Step 1: View Service operation details  [](service-details)
+### Step 1: View Service operation details  [](service-details)
 To modify configuration parameters, first select the Service that 
 you want to modify. This will display the _service details_ which list tabs
 across the top: Overview, Operations, Metrics, Logs, and Settings.
@@ -25,7 +25,7 @@ Select **_Settings_**.
 
 <img class="main-content__illustration" src="https://assets.iobeam.com/images/docs/forge_images/timescale-forge-service-settings-basic.png" alt="View Timescale Forge service operational information"/>
 
-## Step 2: Modify basic parameters [](basic-parameters)
+### Step 2: Modify basic parameters [](basic-parameters)
 Under the Settings tab, you can modify a limited set of the parameters that are
 most often modified in a TimescaleDB or PostgreSQL instance. To modify a 
 configured value, simply click into on the **_value_** that you would like to
@@ -34,7 +34,7 @@ outside of that field will save the value to be applied.
 
 <img class="main-content__illustration" src="https://assets.iobeam.com/images/docs/forge_images/timescale-forge-service-settings-modify.png" alt="View Timescale Forge service settings modification"/>
 
-## Step 3: Apply configuration changes [](apply-changes)
+### Step 3: Apply configuration changes [](apply-changes)
 Once you have modified the basic configuration parameters that you would like to
 change, click the **Apply Changes** button. For some changes, such as `timescaledb.max_background_workers`
 (pictured below), the Service needs to be restarted. Therefore, the


### PR DESCRIPTION
Add information about using the internal hostname for multi-node configurations. Also added anchor tags to relevant sections.

**This shouldn't be published until the update is live on Forge, slated for Monday, 12/21**