### PR TITLE
CMake 3.11 is now required

### DIFF
--- a/getting-started/installation-source-windows.md
+++ b/getting-started/installation-source-windows.md
@@ -5,8 +5,8 @@
 #### Prerequisites
 
 - A standard **PostgreSQL :pg_version: 64-bit** installation
-- Visual Studio 2017 (with [CMake][] and Git components)  
-  **or** Visual Studio 2015/2016 (with [CMake][] version 3.4+ and Git components)
+- Visual Studio 2017 (with [CMake][] and Git components)
+  **or** Visual Studio 2015/2016 (with [CMake][] version 3.11+ and Git components)
 - Make sure all relevant binaries are in your PATH: `pg_config` and `cmake`
 
 #### Build & Install with Local PostgreSQL
@@ -65,7 +65,7 @@ shared_preload_libraries = 'timescaledb'
 Then, restart the PostgreSQL instance.
 
 #### Updating from TimescaleDB 1.x to 2.0
-Once the latest TimescaleDB 2.0 are installed, you can update the EXTENSION 
+Once the latest TimescaleDB 2.0 are installed, you can update the EXTENSION
 in your database as discussed in [Updating Timescale to 2.0][update-tsdb-2].
 
 
@@ -73,7 +73,7 @@ in your database as discussed in [Updating Timescale to 2.0][update-tsdb-2].
 which allows to use all our capabilities.
 To build a version of this software that contains
 source code that is only licensed under Apache License 2.0, pass `-DAPACHE_ONLY=1`
-to `bootstrap`.   
+to `bootstrap`.
 
 [CMake]: https://cmake.org/
 [github-releases]: https://github.com/timescale/timescaledb/releases

--- a/getting-started/installation-source.md
+++ b/getting-started/installation-source.md
@@ -6,7 +6,7 @@
 
 - A standard **PostgreSQL :pg_version:** installation with development environment (header files) (see https://www.postgresql.org/download/ for the appropriate package)
 - C compiler (e.g., gcc or clang)
-- [CMake][] version 3.4 or greater
+- [CMake][] version 3.11 or greater
 
 #### Build & Install with Local PostgreSQL
 >:TIP: It is **highly recommended** that you checkout the latest
@@ -58,7 +58,7 @@ Then, restart the PostgreSQL instance.
 which allows to use all our capabilities.
 To build a version of this software that contains
 source code that is only licensed under Apache License 2.0, pass `-DAPACHE_ONLY=1`
-to `bootstrap`.   
+to `bootstrap`.
 
 [CMake]: https://cmake.org/
 [github-releases]: https://github.com/timescale/timescaledb/releases


### PR DESCRIPTION
CMake 3.11 is now the minimum version: https://github.com/timescale/timescaledb/blob/master/CMakeLists.txt#L1

1. Describe your PR right below:



---
2. Add label for the earliest DB version your changes apply to -->>

3. If you are changing page names or in-page anchors, you must update the
`page-index.js` file

4. Please add at least one content reviewer. If you don't add an
additional reviewer with knowledge about the area you are writing about,
one of the codeowners may add one

5. If this is in response to a posted GitHub issue, please add "Fixes <issue #>"
below so that it's referenced (i.e. "Fixes #122")

5. If you are making simple corrections, reviewers may add comments to your
PR without officially requesting changes. This is to avoid additional
request/review cycles for simple changes. Make sure to address these
comments (i.e. with changes) before your PR is ready to merge

6. Feel free to delete these instructions in your PR message after everything
else is filled out
---
Additional notes:

The default reviewers (CODEOWNERS) are added to each PR.  They will
primarily be reviewing on formatting, not content.  You only need ONE of them
to approve in order to merge your PR
