### PR TITLE
docs: fix data-retention link

### DIFF
--- a/using-timescaledb/continuous-aggregates.md
+++ b/using-timescaledb/continuous-aggregates.md
@@ -551,7 +551,7 @@ SELECT min_time::timestamp FROM device_summary;
 
 
 [fff-system]: https://en.wikipedia.org/wiki/FFF_system
-[sec-data-retention]: /using-timescaledb/data_retention#data-retention
+[sec-data-retention]: /using-timescaledb/data-retention#data-retention
 [postgres-materialized-views]: https://www.postgresql.org/docs/current/rules-materializedviews.html
 [api-continuous-aggs]:/api#continuous-aggregates
 [postgres-createview]: https://www.postgresql.org/docs/current/static/sql-createview.html


### PR DESCRIPTION
PR instructions

1. Describe your PR right below:

Data retention hyperlink is broken since v 1.6

---
2. Add label for the earliest DB version your changes apply to -->>
1.6

3. If you are changing page names or in-page anchors, you must update the
`page-index.js` file

4. Please add at least one content reviewer. If you don't add an
additional reviewer with knowledge about the area you are writing about,
one of the codeowners may add one

5. If this is in response to a posted GitHub issue, please add "Fixes <issue #>"
below so that it's referenced (i.e. "Fixes #122")

5. If you are making simple corrections, reviewers may add comments to your
PR without officially requesting changes. This is to avoid additional
request/review cycles for simple changes. Make sure to address these
comments (i.e. with changes) before your PR is ready to merge

6. Feel free to delete these instructions in your PR message after everything
else is filled out
---
Additional notes:

The default reviewers (CODEOWNERS) are added to each PR.  They will
primarily be reviewing on formatting, not content.  You only need ONE of them
to approve in order to merge your PR
