### PR TITLE
Add clarification on "statement_timeout" for self-hosted

### DIFF
--- a/getting-started/multi-node-self-managed.md
+++ b/getting-started/multi-node-self-managed.md
@@ -23,6 +23,10 @@ data nodes (if not already set, `150` is recommended).
 * `jit` should be set to `off` on the access node as JIT currently
   doesn't work well with distributed queries. JIT can still be enabled
   on the data nodes.
+* `statement_timeout` should be disabled on the data nodes and managed
+  through the access node configuration if desired. This setting is disabled
+  by default in PostgreSQL, but may be worth verifying in your specific
+  environment.
 
 Each of the above settings parameters can be configured for the
 instance in `postgresql.conf`, typically located in the data


### PR DESCRIPTION
Changes were approved in an abandoned PR - but files were renamed in another branch and a rebase got messed up. Easier to just redo them.  ;-)

Based on community feedback found in this thread https://timescaledb.slack.com/archives/CPSD82EMU/p1608590811388100?thread_ts=1607570591.354000&cid=CPSD82EMU