### PR TITLE
Remove experimental warning for tablespaces

### DIFF
--- a/api.md
+++ b/api.md
@@ -444,9 +444,6 @@ SELECT attach_tablespace('disk1', 'conditions');
 SELECT attach_tablespace('disk2', 'conditions', if_not_attached => true);
  ```
 
->:WARNING: The management of tablespaces on hypertables is currently an
-experimental feature.
-
 ---
 
 ## create_hypertable() [](create_hypertable)


### PR DESCRIPTION
Initially tablespace's API was marked as experimental. It is not any
more and thus the experimental warning is removed.
