### PR TITLE
Fix hypertable_detailed_size link

### DIFF
--- a/api.md
+++ b/api.md
@@ -36,7 +36,7 @@
 > - [get_telemetry_report](#get_telemetry_report)
 > - [histogram](#histogram)
 > - [hypertable_compression_stats](#hypertable_compression_stats)
-> - [hypertable_detailed_size](#hypertable_size)
+> - [hypertable_detailed_size](#hypertable_detailed_size)
 > - [hypertable_index_size](#hypertable_index_size)
 > - [hypertable_size](#hypertable_size)
 > - [interpolate](#interpolate)


### PR DESCRIPTION
This fixes wrong link in the command list sidebar.
![Screenshot from 2021-03-25 11-40-31](https://user-images.githubusercontent.com/141308/112444325-f8782e00-8d5e-11eb-85c2-d334f080f564.png)
