### PR TITLE
Fixed typo

### DIFF
--- a/update-timescaledb/update-tsdb-2.md
+++ b/update-timescaledb/update-tsdb-2.md
@@ -77,7 +77,7 @@ Execute the following SQL to save current settings for Continuous Aggregates and
 
 **Continuous Aggregate Stats**
 ```SQL
-\COPY timescaledb_information.continuous_aggregates_stats TO ‘continuous_aggregates_stats.csv’ csv header
+\COPY timescaledb_information.continuous_aggregate_stats TO ‘continuous_aggregate_stats.csv’ csv header
 ```
 
 **Drop Chunk Policies**


### PR DESCRIPTION
There was an s in continuous_aggregate**s**_stats.