### PR TITLE
fix(quickstart-node): Fix broken link in "Generate hypertable" tip, add link for Sequelize, fix code

### DIFF
--- a/tutorials/quickstart-node.md
+++ b/tutorials/quickstart-node.md
@@ -433,7 +433,7 @@ app.get('/', async (req, res) => {
         });
 
         // send response 
-        res.send('Inserted!);
+        res.send('Inserted!');
     } catch (e) {
         console.log('Error inserting data', e)
     }

--- a/tutorials/quickstart-node.md
+++ b/tutorials/quickstart-node.md
@@ -494,3 +494,4 @@ Node application, be sure to check out these advanced TimescaleDB tutorials:
 [hypertables]: /introduction/architecture
 [node-install]: https://nodejs.org
 [npm-install]: https://www.npmjs.com/get-npm
+[sequelize-info]: https://sequelize.org/

--- a/tutorials/quickstart-node.md
+++ b/tutorials/quickstart-node.md
@@ -357,7 +357,7 @@ all be executed on the hypertable.
 A hypertable is defined by a standard schema with column names and types, with at 
 least one column specifying a time value.
 
->:TIP: The TimescaleDB documentation on [schema management and indexing[indexing-api-guide] explains this in further detail. 
+>:TIP: The TimescaleDB documentation on [schema management and indexing][indexing-api-guide] explains this in further detail. 
 
 Let's create this migration to modify the `page_loads` table and create a
 hypertable by first running the following command:


### PR DESCRIPTION
Fixes a small error that make the tip look like this right now:

![image](https://user-images.githubusercontent.com/183673/113515530-5da8fc00-9575-11eb-84e8-a36b72beb4de.png)

And adds an actual link for Sequelize so this misrender is also gone:

![image](https://user-images.githubusercontent.com/183673/113516212-423ff000-9579-11eb-8029-a359ae0e1b75.png)
