### PR TITLE
Update distributed compression policy changes

### DIFF
--- a/api.md
+++ b/api.md
@@ -1659,7 +1659,13 @@ suggest using the policy framework instead.
 
 |Name|Description|
 |---|---|
-| `if_not_compressed` | (BOOLEAN) Setting to true will skip chunks that are already compressed. Defaults to false.|
+| `if_not_compressed` | (BOOLEAN) Setting to true will skip chunks that are already compressed, but still succeed. Defaults to false.|
+
+#### Returns [](compress_chunk-returns)
+
+|Column|Description|
+|---|---|
+|`compress_chunk`| (REGCLASS) Name of the chunk that was compressed|
 
 #### Sample Usage [](compress_chunk-sample-usage)
 Compress a single chunk.

--- a/using-timescaledb/limitations.md
+++ b/using-timescaledb/limitations.md
@@ -27,9 +27,6 @@ to distributed hypertables:
   created on an access node are scheduled and executed on this access node 
   without distributing the jobs to data nodes.
 - Continuous aggregates are not supported.
-- Compression policies are not supported. However, you can enable 
-  compression on the distributed hypertable and manually 
-  execute `compress_chunk`.
 - Reordering chunks is not supported.
 - Tablespaces cannot be attached to a distributed hypertable on the
   access node. It is still possible attach tablespaces on data nodes.
@@ -53,7 +50,7 @@ to distributed hypertables:
   registered with `set_integer_now_func`.
 
 Note that these limitations concern usage from the access node. Some
-currently unsupported features (like compression policy or
+currently unsupported features (like
 continuous aggregates) might still work on individual data nodes, but
 such usage is neither tested nor officially supported. Future versions
 of TimescaleDB might remove some of these limitations.


### PR DESCRIPTION
Improve the if_not_compressed optional argument description.
Document the return value for compress_chunk().
