### PR TITLE
Warn about using multiple workers with pg_restore

### DIFF
--- a/using-timescaledb/backup.md
+++ b/using-timescaledb/backup.md
@@ -52,6 +52,20 @@ SELECT timescaledb_pre_restore();
 SELECT timescaledb_post_restore();
 ```
 
+>:WARNING: Using the flag `-j` with `pg_restore` to restore using
+>multiple workers is not supported and might generate errors. You can
+>use it if you first restore the entire schema and the
+>`_timescaledb_catalog` schema without the `-j` option, for example:
+>```
+>pg_restore -Fc -s -d tutorial tutorial.bak
+>pg_restore -Fc -a -n _timescaledb_catalog -d tutorial tutorial.bak
+>```
+>And then restore the rest of the database with the `-j` option using
+> the `-N` option, for example:
+>```
+>pg_restore -Fc -a -N _timescaledb_catalog -j4 -d tutorial tutorial.bak
+>```
+
 >:WARNING: PostgreSQL's `pg_dump` does not currently specify the *version* of
  the extension in its backup, which leads to problems if you are
  restoring into a database instance with a more recent extension


### PR DESCRIPTION
Warn about using multiple workers when restoring and provide
description of how to use multiple workers with `pg_restore` correctly.

PR instructions

1. Describe your PR right below:



---
2. Add label for the earliest DB version your changes apply to -->>

3. If you are changing page names or in-page anchors, you must update the
`page-index.js` file

4. Please add at least one content reviewer. If you don't add an
additional reviewer with knowledge about the area you are writing about,
one of the codeowners may add one

5. If this is in response to a posted GitHub issue, please add "Fixes <issue #>"
below so that it's referenced (i.e. "Fixes #122")

5. If you are making simple corrections, reviewers may add comments to your
PR without officially requesting changes. This is to avoid additional
request/review cycles for simple changes. Make sure to address these
comments (i.e. with changes) before your PR is ready to merge

6. Feel free to delete these instructions in your PR message after everything
else is filled out
---
Additional notes:

The default reviewers (CODEOWNERS) are added to each PR.  They will
primarily be reviewing on formatting, not content.  You only need ONE of them
to approve in order to merge your PR
