### PR TITLE
Document how to pass extra config parameters through Docker Compose

### DIFF
--- a/getting-started/configuring.md
+++ b/getting-started/configuring.md
@@ -310,6 +310,16 @@ command via a `-c` option, as in the following.
 docker run -i -t timescale/timescaledb:latest-pg10 postgres -cmax_wal_size=2GB
 ```
 
+For Docker Compose, you can pass extra config parameters in the `command` section.
+
+```yaml
+version: '3'
+services:
+  timescaledb:
+    image: timescale/timescaledb:latest
+    command: -cmax_wal_size=2GB
+```    
+
 Additional examples of passing in arguments at boot can be found in our
 [discussion about using WAL-E][wale] for incremental backup.
 


### PR DESCRIPTION
This was not immediately obvious for new users.

PR instructions

1. Describe your PR right below:

Adding how to set config documentation for Docker Compose - applies to all known versions
