### PR TITLE
docs: fix broken NYC dataset download link

### DIFF
--- a/tutorials/tutorial-hello-timescale.md
+++ b/tutorials/tutorial-hello-timescale.md
@@ -812,7 +812,7 @@ Ready for more learning? Here’s a few suggestions:
 [install-timescale]: /getting-started/installation
 [setup-psql]: /getting-started/install-psql-tutorial
 [NYCTLC]: https://www1.nyc.gov/site/tlc/about/tlc-trip-record-data.page
-[nyc_data]: https://timescaledata.blob.core.windows.net/datasets/nyc_data.tar.gz
+[nyc_data]: https://assets.timescale.com/docs/downloads/nyc_data.tar.gz
 [postgis]: http://postgis.net/documentation
 [time-series-forecasting]: /tutorials/tutorial-forecasting
 [continuous-aggregates]: /tutorials/continuous-aggs-tutorial


### PR DESCRIPTION
PR instructions

1. Describe your PR right below:

This PR fixes a broken download link in the Hello Timescale tutorial.
The link for the NYC Taxi dataset was pointing to an old blob storage URL and has been updated to the current official Timescale assets location.

---
2. Add label for the earliest DB version your changes apply to -->> DB 2.0+ (applies to all currently supported versions, since this is docs-only)

3. If you are changing page names or in-page anchors, you must update the
`page-index.js` file

N/A

4. Please add at least one content reviewer. If you don't add an
additional reviewer with knowledge about the area you are writing about,
one of the codeowners may add one

5. If this is in response to a posted GitHub issue, please add "Fixes <issue #>"
below so that it's referenced (i.e. "Fixes #122")

5. If you are making simple corrections, reviewers may add comments to your
PR without officially requesting changes. This is to avoid additional
request/review cycles for simple changes. Make sure to address these
comments (i.e. with changes) before your PR is ready to merge

N/A

6. Feel free to delete these instructions in your PR message after everything
else is filled out
---
Additional notes:



Additional notes:
Simple correction in tutorials/tutorial-hello-timescale.md to fix a broken link:

Before: https://timescaledata.blob.core.windows.net/datasets/nyc_data.tar.gz

After: https://assets.timescale.com/docs/downloads/nyc_data.tar.gz


The default reviewers (CODEOWNERS) are added to each PR.  They will
primarily be reviewing on formatting, not content.  You only need ONE of them
to approve in order to merge your PR
